### PR TITLE
Safari toolbar bug

### DIFF
--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -1,4 +1,3 @@
-
 /**
  * MailDev - style.css
  *
@@ -215,6 +214,10 @@ body {
 
     li {
         padding: 0 0.5em;
+        display: inline-block;
+    }
+    .dropdown-menu li {
+        display: block;
     }
 
     .fa {


### PR DESCRIPTION
Hi

It seems toolbar items are being stacked vertically in Safari (only tested on Mac OS X) and hereby breaking some of the toolbar layout.
