### PR TITLE
Lock down package versions in package.json. Closes #18.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,24 +31,24 @@
     }
   ],
   "dependencies": {
-    "express": "3.x",
-    "simplesmtp": "*",
-    "mailparser": "*",
-    "mailcomposer": "*",
+    "express": "~3.10.3",
+    "simplesmtp": "~0.3.32",
+    "mailparser": "~0.3.6",
+    "mailcomposer": "~0.2.11",
     "socket.io": "~0.9.17",
     "commander": "~2.1.0",
-    "open": "0.0.4"
+    "open": "~0.0.5"
   },
   "devDependencies": {
-    "grunt": ">=0.4.1",
-    "grunt-contrib-watch": "*",
-    "grunt-contrib-jshint": "*",
-    "matchdep": "~0.1.1",
     "async": "~0.2.9",
-    "nodemailer": "~0.5.11",
-    "grunt-sass": "~0.9.0",
+    "grunt": "^0.4.5",
+    "grunt-concurrent": "~0.4.2",
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-nodemon": "~0.1.2",
-    "grunt-concurrent": "~0.4.2"
+    "grunt-sass": "~0.9.0",
+    "matchdep": "~0.1.1",
+    "nodemailer": "~0.5.11"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Will be in the MailDev 0.5.2 release.
