### PR TITLE
update documentation for NodeMailer 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@
 
 Configure your application to send emails via port `1025` and open `localhost:1080` in your browser.
 
-**Nodemailer**
+**Nodemailer (v1.0+)**
+
+    var transport = nodemailer.createTransport({
+        port: 1025,
+        ignoreTLS: true,
+        // other settings...
+    });
+
+**Nodemailer (v0.7)**
 
     var transport = nodemailer.createTransport("SMTP", {
         port: 1025,


### PR DESCRIPTION
The documentation in the README is for Nodemailer 0.7.  Updated to include doc for Nodemailer 1.0+
