### PR TITLE
Add missing dev dependency on grunt-contrib-compass

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "async": "~0.2.9",
     "grunt": "^0.4.5",
     "grunt-concurrent": "~0.4.2",
+    "grunt-contrib-compass": "^1.0.1",
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-nodemon": "~0.1.2",


### PR DESCRIPTION
Without this "grunt dev" errors with:

Warning: Task "compass:dist" not found. Use --force to continue.
Aborted due to warnings.
