### PR TITLE
Remove old compass refs from Gruntfile.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     },
 
     watch: {
-      compass: {
+      sass: {
         files: ['<%= path.assets %>/styles/{,*/}*.{scss,sass}'],
         tasks: ['sass']
       }
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', [
     'jshint',
-    'compass:dist'
+    'sass'
   ]);
 
   grunt.registerTask('default', ['build']);


### PR DESCRIPTION
The project no longer uses compass so this removes references to compass in `Gruntfile.js`. This PR closes #23.
