### PR TITLE
Only show Relay button when available.

### DIFF
--- a/app/views/item.html
+++ b/app/views/item.html
@@ -96,7 +96,8 @@
     </li>
     <li>
         <a href="" class=""
-          ng-click="relay(item)">
+          ng-click="relay(item)"
+          ng-show="!!config.outgoingHost">
             <i class="fa fa-cloud-upload"></i>
             Relay
         </a>


### PR DESCRIPTION
Follow up to #22 which only shows the relay button if the app has the relay feature configured.
