### PR TITLE
Support running on remote machine

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -18,7 +18,7 @@ app.config(['$routeProvider', function($routeProvider){
 app.run(['$rootScope', function($rootScope){
   
   // Connect Socket.io
-  var socket = io('http://localhost');
+  var socket = io();
 
   socket.on('newMail', function(data) {
     $rootScope.$emit('Refresh');


### PR DESCRIPTION
Running on a remote machine (e.g. some server) mostly works, but the web UI
doesn't refresh automatically because socket.io is hard-coded to
'http://localhost'.

There's no need to hard-code this - if you just use socket.io's default then
it works for localhost and/or a remote server too, depending on which URL
you typed in the browser to load the MailDev UI.
