### PR TITLE
Don't reuse outgoing smtp connections

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -347,6 +347,7 @@ mailServer.setupOutgoing = function(host, port, user, pass, secure){
           user: user
         , pass: pass
         }
+      , maxMessages: 1
       , debug: true
       };
     mailServer.clientPool = simplesmtp.createClientPool(port, host, options);


### PR DESCRIPTION
Was getting failures with Sendgrid and timeouts.  Not sure if other SMTP
providers are affected, but this seems like a reasonable fix.
