### PR TITLE
Allow SMTP forwarding without username and password

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -343,12 +343,17 @@ mailServer.setupOutgoing = function(host, port, user, pass, secure){
     // Forward Mail options
     var options = {
         secureConnection: secure
-      , auth: {
-          user: user
-        , pass: pass
-        }
       , debug: true
       };
+
+    if(pass && user) {
+      options.auth = {
+        user: user,
+        pass: pass
+      };
+    }
+
+
     mailServer.clientPool = simplesmtp.createClientPool(port, host, options);
 
     logger.info(


### PR DESCRIPTION
Forwarding emails through an open email relay fails, even when the username and password options are not set.
