### PR TITLE
Use relative href for iframe src

### DIFF
--- a/app/scripts/controllers/item.js
+++ b/app/scripts/controllers/item.js
@@ -23,7 +23,7 @@ app.controller('ItemCtrl', [
         $scope.item = new Email(email);
 
         if ($scope.item.html) {
-          $scope.item.iframeUrl = '/email/' + $scope.item.id + '/html';
+          $scope.item.iframeUrl = 'email/' + $scope.item.id + '/html';
           prepIframe();
           $scope.panelVisibility = 'html';
         } else {


### PR DESCRIPTION
Missed this in the last PR - view an email in HTML format causes the message to be loaded into the iframe using an absolute URL.

This results in the iframe not loading correctly when using MailDev through a reverse proxy.
