### PR TITLE
Fix module entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maildev",
   "description": "SMTP Server and Web Interface for reading and testing emails during development",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "keywords": [
     "email",
     "e-mail",


### PR DESCRIPTION
As discovered in #39. MailDev wasn't require-able as the entry point was incorrect.
