### PR TITLE
Should be able to use both STARTTLS and AUTH (Fixed #187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierprio
       --web-pass <password>           HTTP password for GUI
       --base-pathname <path>          base path for URLs
       --disable-web                   Disable the use of the web interface. Useful for unit testing
-      --hide-extensions <extensions>  Comma separated list of SMTP extensions to NOT advertise
-                                      (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)
+      --disabled-commands <commands>  Comma separated list of SMTP commands to NOT advertise
       -o, --open                      Open the Web GUI after startup
       -v, --verbose
       --silent

--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ module.exports = function (config) {
       .option('--web-pass <password>', 'HTTP password for GUI')
       .option('--base-pathname <path>', 'base path for URLs')
       .option('--disable-web', 'Disable the use of the web interface. Useful for unit testing')
-      .option('--hide-extensions <extensions>',
-        'Comma separated list of SMTP extensions to NOT advertise (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)',
+      .option('--disabled-commands <commands>',
+        'Comma separated list of SMTP commands to NOT advertise',
         function (val) { return val.split(',') }
       )
       .option('-o, --open', 'Open the Web GUI after startup')
@@ -54,7 +54,7 @@ module.exports = function (config) {
   }
 
   // Start the Mailserver & Web GUI
-  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.hideExtensions)
+  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.disabledCommands)
 
   if (config.outgoingHost ||
       config.outgoingPort ||

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -164,14 +164,13 @@ function createTempFolder () {
  * Create and configure the mailserver
  */
 
-mailServer.create = function (port, host, user, password, hideExtensions) {
-  const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
-  const smtpServerConfig = Object.assign({
+mailServer.create = function (port, host, user, password, disabledCommands) {
+  const smtpServerConfig = {
     onAuth: smtpHelpers.createOnAuthCallback(user, password),
     onData: handleDataStream,
     logger: false,
-    disabledCommands: (user && password) ? ['STARTTLS'] : ['AUTH']
-  }, hideExtensionOptions)
+    disabledCommands: disabledCommands || []
+  }
 
   const smtp = new SMTPServer(smtpServerConfig)
 
@@ -186,28 +185,6 @@ mailServer.create = function (port, host, user, password, hideExtensions) {
   // testability requires this to be exposed.
   // otherwise we cannot test whether error handling works
   mailServer.smtp = smtp
-}
-
-const HIDEABLE_EXTENSIONS = [
-  'STARTTLS',
-  'PIPELINING',
-  '8BITMIME',
-  'SMTPUTF8'
-]
-
-function getHideExtensionOptions (extensions) {
-  if (!extensions) {
-    return {}
-  }
-  return extensions.reduce(function (options, extension) {
-    const ext = extension.toUpperCase()
-    if (HIDEABLE_EXTENSIONS.indexOf(ext) > -1) {
-      options[`hide${ext}`] = true
-    } else {
-      throw new Error(`Invalid hideable extension: ${ext}`)
-    }
-    return options
-  }, {})
 }
 
 /**

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -59,7 +59,8 @@ describe('API', function () {
     it('should receive emails', function (done) {
       const maildev = new MailDev({
         silent: true,
-        disableWeb: true
+        disableWeb: true,
+        disabledCommands: ['AUTH']
       })
 
       const emailOpts = {
@@ -102,7 +103,8 @@ describe('API', function () {
     it('should emit events when receiving emails', function (done) {
       const maildev = new MailDev({
         silent: true,
-        disableWeb: true
+        disableWeb: true,
+        disabledCommands: ['AUTH']
       })
 
       const transporter = nodemailer.createTransport({

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -14,7 +14,8 @@ const nodemailer = require('nodemailer')
 const MailDev = require('../index.js')
 
 const defaultMailDevOpts = {
-  silent: true
+  silent: true,
+  disabledCommands: ['AUTH']
 }
 
 const defaultNodemailerOpts = {

--- a/test/mailserver.test.js
+++ b/test/mailserver.test.js
@@ -34,7 +34,8 @@ describe('mailserver', function () {
         incomingUser: 'bodhi',
         incomingPass: 'surfing',
         silent: true,
-        disableWeb: true
+        disableWeb: true,
+        disabledCommands: ['STARTTLS']
       })
 
       maildev.listen(function (err) {
@@ -73,7 +74,8 @@ describe('mailserver', function () {
         incomingUser: 'bodhi',
         incomingPass: 'surfing',
         silent: true,
-        disableWeb: true
+        disableWeb: true,
+        disabledCommands: ['STARTTLS']
       })
 
       maildev.listen(function (err) {


### PR DESCRIPTION
Currently, the case of transmitting both STARTTLS and AUTH can not be covered.

Like smtp-server module, not only extended commands, but all unnecessary commands should be controllable.