### PR TITLE
Provide a way of limiting the mail storage size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierprio
       --disable-web                   Disable the use of the web interface. Useful for unit testing
       --hide-extensions <extensions>  Comma separated list of SMTP extensions to NOT advertise
                                       (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)
+      --store-limit <limit>           Limit the number of stored messages
       -o, --open                      Open the Web GUI after startup
       -v, --verbose
       --silent

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function (config) {
         'Comma separated list of SMTP extensions to NOT advertise (STARTTLS, SMTPUTF8, PIPELINING, 8BITMIME)',
         function (val) { return val.split(',') }
       )
+      .option('--store-limit <limit>', 'Limit the number of stored messages')
       .option('-o, --open', 'Open the Web GUI after startup')
       .option('-v, --verbose')
       .option('--silent')
@@ -54,7 +55,14 @@ module.exports = function (config) {
   }
 
   // Start the Mailserver & Web GUI
-  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.hideExtensions)
+  mailserver.create(
+    config.smtp,
+    config.ip,
+    config.incomingUser,
+    config.incomingPass,
+    config.hideExtensions,
+    config.storeLimit
+  )
 
   if (config.outgoingHost ||
       config.outgoingPort ||

--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ module.exports = function (config) {
     config.ip,
     config.incomingUser,
     config.incomingPass,
-    config.hideExtensions,
-    config.storeLimit
+    config.hideExtensions
   )
 
   if (config.outgoingHost ||
@@ -76,6 +75,10 @@ module.exports = function (config) {
       config.outgoingPass,
       config.outgoingSecure
     )
+  }
+
+  if (config.storeLimit) {
+    mailserver.setStoreLimit(config.storeLimit)
   }
 
   if (config.autoRelay) {

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -57,6 +57,11 @@ function saveEmail (id, envelope, mailObject) {
 
   store.push(object)
 
+  if (mailServer.storeLimit && store.length > mailServer.storeLimit) {
+    const removedMail = store.shift()
+    eventEmitter.emit('delete', {id: removedMail.id, index: 0})
+  }
+
   logger.log('Saving email: ', mailObject.subject)
 
   if (outgoing.isAutoRelayEnabled()) {
@@ -161,7 +166,7 @@ function createTempFolder () {
  * Create and configure the mailserver
  */
 
-mailServer.create = function (port, host, user, password, hideExtensions) {
+mailServer.create = function (port, host, user, password, hideExtensions, storeLimit) {
   const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
   const smtpServerConfig = Object.assign({
     onAuth: smtpHelpers.createOnAuthCallback(user, password),
@@ -179,6 +184,7 @@ mailServer.create = function (port, host, user, password, hideExtensions) {
 
   mailServer.port = port || defaultPort
   mailServer.host = host || defaultHost
+  mailServer.storeLimit = storeLimit
 
   // testability requires this to be exposed.
   // otherwise we cannot test whether error handling works

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -166,7 +166,7 @@ function createTempFolder () {
  * Create and configure the mailserver
  */
 
-mailServer.create = function (port, host, user, password, hideExtensions, storeLimit) {
+mailServer.create = function (port, host, user, password, hideExtensions) {
   const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
   const smtpServerConfig = Object.assign({
     onAuth: smtpHelpers.createOnAuthCallback(user, password),
@@ -184,7 +184,6 @@ mailServer.create = function (port, host, user, password, hideExtensions, storeL
 
   mailServer.port = port || defaultPort
   mailServer.host = host || defaultHost
-  mailServer.storeLimit = storeLimit
 
   // testability requires this to be exposed.
   // otherwise we cannot test whether error handling works
@@ -430,6 +429,13 @@ mailServer.isOutgoingEnabled = function () {
 
 mailServer.getOutgoingHost = function () {
   return outgoing.getOutgoingHost()
+}
+
+/**
+ * Setup store limit
+ */
+mailServer.setStoreLimit = function (storeLimit) {
+  mailServer.storeLimit = storeLimit
 }
 
 /**


### PR DESCRIPTION
MailDev may sometimes be used as a part of a development/staging environment where the process may be running for a very long time without interruption. In those cases, it is undesirable to let that
process grow freely. This limit makes sure that the memory usage is bounded.