### PR TITLE
Add option to specify directory for mail storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierprio
       -s, --smtp <port>               SMTP port to catch emails [1025]
       -w, --web <port>                Port to run the Web GUI [1080]
       --ip <ip address>               IP Address to bind SMTP service to
+      --mail-directory <path>         Mail directory for storing mails and attachements, defaults to
+                                      os specific temp directory
       --outgoing-host <host>          SMTP host for outgoing emails
       --outgoing-port <port>          SMTP port for outgoing emails
       --outgoing-user <user>          SMTP user for outgoing emails

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = function (config) {
       .option('-s, --smtp <port>', 'SMTP port to catch emails [1025]', '1025')
       .option('-w, --web <port>', 'Port to run the Web GUI [1080]', '1080')
       .option('--ip <ip address>', 'IP Address to bind SMTP service to', '0.0.0.0')
+      .option('--mail-directory <path>', 'Directory for persisting mails')
       .option('--outgoing-host <host>', 'SMTP host for outgoing emails')
       .option('--outgoing-port <port>', 'SMTP port for outgoing emails')
       .option('--outgoing-user <user>', 'SMTP user for outgoing emails')
@@ -54,7 +55,7 @@ module.exports = function (config) {
   }
 
   // Start the Mailserver & Web GUI
-  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.hideExtensions)
+  mailserver.create(config.smtp, config.ip, config.mailDirectory, config.incomingUser, config.incomingPass, config.hideExtensions)
 
   if (config.outgoingHost ||
       config.outgoingPort ||

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -19,7 +19,7 @@ const outgoing = require('./outgoing')
 const defaultPort = 1025
 const defaultHost = '0.0.0.0'
 const store = []
-const tempDir = path.join(os.tmpdir(), 'maildev', process.pid.toString())
+const defaultMailDir = path.join(os.tmpdir(), 'maildev', process.pid.toString())
 const eventEmitter = new events.EventEmitter()
 
 /**
@@ -54,7 +54,7 @@ function saveEmail (id, envelope, mailObject) {
   object.time = new Date()
   object.read = false
   object.envelope = envelope
-  object.source = path.join(tempDir, id + '.eml')
+  object.source = path.join(mailServer.mailDir, id + '.eml')
 
   store.push(object)
 
@@ -71,10 +71,10 @@ function saveEmail (id, envelope, mailObject) {
 
 // Save an attachment
 function saveAttachment (id, attachment) {
-  if (!fs.existsSync(path.join(tempDir, id))) {
-    fs.mkdirSync(path.join(tempDir, id))
+  if (!fs.existsSync(path.join(mailServer.mailDir, id))) {
+    fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
-  var output = fs.createWriteStream(path.join(tempDir, id, attachment.contentId))
+  var output = fs.createWriteStream(path.join(mailServer.mailDir, id, attachment.contentId))
   attachment.stream.pipe(output)
 }
 
@@ -88,7 +88,7 @@ function createSaveStream (id, emailData) {
 }
 
 function createRawStream (id) {
-  return fs.createWriteStream(path.join(tempDir, id + '.eml'))
+  return fs.createWriteStream(path.join(mailServer.mailDir, id + '.eml'))
 }
 
 function handleDataStream (stream, session, callback) {
@@ -113,15 +113,14 @@ function handleDataStream (stream, session, callback) {
 }
 
 /**
- * Delete everything in the temp folder
+ * Delete everything in the mail directory
  */
-
-function clearTempFolder () {
-  fs.readdir(tempDir, function (err, files) {
+function clearMailDir () {
+  fs.readdir(mailServer.mailDir, function (err, files) {
     if (err) throw err
 
     files.forEach(function (file) {
-      rimraf(path.join(tempDir, file), function (err) {
+      rimraf(path.join(mailServer.mailDir, file), function (err) {
         if (err) throw err
       })
     })
@@ -129,23 +128,23 @@ function clearTempFolder () {
 }
 
 /**
- * Create temp folder
+ * Create mail directory
  */
 
-function createTempFolder () {
-  if (fs.existsSync(tempDir)) {
-    clearTempFolder()
+function createMailDir () {
+  if (fs.existsSync(mailServer.mailDir)) {
+    clearMailDir()
     return
   }
 
-  if (!fs.existsSync(path.dirname(tempDir))) {
-    fs.mkdirSync(path.dirname(tempDir))
-    logger.log('Temporary directory created at %s', path.dirname(tempDir))
+  if (!fs.existsSync(path.dirname(mailServer.mailDir))) {
+    fs.mkdirSync(path.dirname(mailServer.mailDir))
+    logger.log('Mail directory created at %s', path.dirname(mailServer.mailDir))
   }
 
-  if (!fs.existsSync(tempDir)) {
-    fs.mkdirSync(tempDir)
-    logger.log('Temporary directory created at %s', tempDir)
+  if (!fs.existsSync(mailServer.mailDir)) {
+    fs.mkdirSync(mailServer.mailDir)
+    logger.log('Mail directory created at %s', mailServer.mailDir)
   }
 }
 
@@ -153,7 +152,7 @@ function createTempFolder () {
  * Create and configure the mailserver
  */
 
-mailServer.create = function (port, host, user, password, hideExtensions) {
+mailServer.create = function (port, host, mailDir, user, password, hideExtensions) {
   const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
   const smtpServerConfig = Object.assign({
     onAuth: smtpHelpers.createOnAuthCallback(user, password),
@@ -166,11 +165,11 @@ mailServer.create = function (port, host, user, password, hideExtensions) {
 
   smtp.on('error', mailServer.onSmtpError)
 
-  // Setup temp folder for attachments
-  createTempFolder()
-
   mailServer.port = port || defaultPort
   mailServer.host = host || defaultHost
+
+  mailServer.mailDir = mailDir || defaultMailDir
+  createMailDir()
 
   // testability requires this to be exposed.
   // otherwise we cannot test whether error handling works
@@ -275,7 +274,7 @@ mailServer.getRawEmail = function (id, done) {
   mailServer.getEmail(id, function (err, email) {
     if (err) return done(err)
 
-    done(null, fs.createReadStream(path.join(tempDir, id + '.eml')))
+    done(null, fs.createReadStream(path.join(mailServer.mailDir, id + '.eml')))
   })
 }
 
@@ -346,7 +345,7 @@ mailServer.deleteEmail = function (id, done) {
   }
 
   // delete raw email
-  fs.unlink(path.join(tempDir, id + '.eml'), function (err) {
+  fs.unlink(path.join(mailServer.mailDir, id + '.eml'), function (err) {
     if (err) {
       logger.error(err)
     } else {
@@ -355,7 +354,7 @@ mailServer.deleteEmail = function (id, done) {
   })
 
   if (email.attachments) {
-    rimraf(path.join(tempDir, id), function (err) {
+    rimraf(path.join(mailServer.mailDir, id), function (err) {
       if (err) throw err
     })
   }
@@ -374,7 +373,7 @@ mailServer.deleteEmail = function (id, done) {
 mailServer.deleteAllEmail = function (done) {
   logger.warn('Deleting all email')
 
-  clearTempFolder()
+  clearMailDir()
   store.length = 0
   eventEmitter.emit('delete', { id: 'all' })
 
@@ -401,7 +400,7 @@ mailServer.getEmailAttachment = function (id, filename, done) {
       return done(new Error('Attachment not found'))
     }
 
-    done(null, match.contentType, fs.createReadStream(path.join(tempDir, id, match.contentId)))
+    done(null, match.contentType, fs.createReadStream(path.join(mailServer.mailDir, id, match.contentId)))
   })
 }
 
@@ -471,6 +470,6 @@ mailServer.getEmailEml = function (id, done) {
 
     var filename = email.id + '.eml'
 
-    done(null, 'message/rfc822', filename, fs.createReadStream(path.join(tempDir, id + '.eml')))
+    done(null, 'message/rfc822', filename, fs.createReadStream(path.join(mailServer.mailDir, id + '.eml')))
   })
 }


### PR DESCRIPTION
Mails and attachments are not stored in a os dependent temporary directory, but
in a given directory. This is useful in containerized environments where
persistent volumes are mapped to folders in the container.