### PR TITLE
remember autoShow state in locale storage (if available)

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -10,7 +10,7 @@ app.controller('MainCtrl', [
     $scope.items = []
     $scope.configOpen = false
     $scope.currentItemId = null
-    $scope.autoShow = false
+    $scope.autoShow = window.localStorage && window.localStorage.getItem('MailDev.autoShow') === '1'
     $scope.unreadItems = 0
 
     var countUnread = function () {
@@ -91,6 +91,9 @@ app.controller('MainCtrl', [
 
     $scope.toggleAutoShow = function () {
       $scope.autoShow = !$scope.autoShow
+      if (window.localStorage) {
+        window.localStorage.setItem('MailDev.autoShow', $scope.autoShow ? '1' : '0')
+      }
     }
 
     // Initialize the view


### PR DESCRIPTION
The autoShow state wasn't remember between page refreshes.

When MailDev interface loads the autoShow state will be retrieved from local storage.
When autoShow state changes, the state will be persisted in local storage.