### PR TITLE
Handle SMTPConnection errors. Fixes #287.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage: maildev [options]
 |`--outgoing-user <user>`|`MAILDEV_OUTGOING_USER`|SMTP user for outgoing emails|
 |`--outgoing-pass <password>`|`MAILDEV_OUTGOING_PASS`|SMTP password for outgoing emails|
 |`--outgoing-secure`|`MAILDEV_OUTGOING_SECURE`|Use SMTP SSL for outgoing emails|
-|`--auto-relay <email>`|`MAILDEV_AUTO_RELAY`|Use auto-relay mode. Optional relay email address|
+|`--auto-relay [email]`|`MAILDEV_AUTO_RELAY`|Use auto-relay mode. Optional relay email address|
 |`--auto-relay-rules <file>`|`MAILDEV_AUTO_RELAY_RULES`|Filter rules for auto relay mode|
 |`--incoming-user <user>`|`MAILDEV_INCOMING_USER`|SMTP user for incoming emails|
 |`--incoming-pass <pass>`|`MAILDEV_INCOMING_PASS`|SMTP password for incoming emails|

--- a/lib/options.js
+++ b/lib/options.js
@@ -11,7 +11,7 @@ module.exports.options = [
   ['--outgoing-user <user>', 'MAILDEV_OUTGOING_USER', 'SMTP user for outgoing emails'],
   ['--outgoing-pass <password>', 'MAILDEV_OUTGOING_PASS', 'SMTP password for outgoing emails'],
   ['--outgoing-secure', 'MAILDEV_OUTGOING_SECURE', 'Use SMTP SSL for outgoing emails', false],
-  ['--auto-relay <email>', 'MAILDEV_AUTO_RELAY', 'Use auto-relay mode. Optional relay email address'],
+  ['--auto-relay [email]', 'MAILDEV_AUTO_RELAY', 'Use auto-relay mode. Optional relay email address'],
   ['--auto-relay-rules <file>', 'MAILDEV_AUTO_RELAY_RULES', 'Filter rules for auto relay mode'],
   ['--incoming-user <user>', 'MAILDEV_INCOMING_USER', 'SMTP user for incoming emails'],
   ['--incoming-pass <pass>', 'MAILDEV_INCOMING_PASS', 'SMTP password for incoming emails'],

--- a/lib/outgoing.js
+++ b/lib/outgoing.js
@@ -56,6 +56,8 @@ outgoing._createClient = function () {
       debug: true
     })
 
+    client.on('error', function (err) { logger.error('SMTP Connection error for outgoing email: ', err) })
+
     logger.info(
       'MailDev outgoing SMTP Server %s:%d (user:%s, pass:%s, secure:%s)',
       config.host,


### PR DESCRIPTION
### Purpose
Handle SMTPConnection errors gracefully. Fixes #287.

### Notes
> If an EventEmitter does not have at least one listener registered for the 'error' event, and an 'error' event is emitted, the error is thrown, a stack trace is printed, and the Node.js process exits. ([source - Node.js official docs](https://nodejs.org/api/events.html#events_error_events))
- Without handling SMTPConnection's error, the app would always have a fatal error and exit
- Thanks to @heldchen for the fix as documented in #287