### PR TITLE
Add persistence support 

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (config) {
   }
 
   // Start the Mailserver & Web GUI
-  mailserver.create(config.smtp, config.ip, config.incomingUser, config.incomingPass, config.hideExtensions)
+  mailserver.create(config.smtp, config.ip, config.mailDirectory, config.incomingUser, config.incomingPass, config.hideExtensions)
 
   if (config.outgoingHost ||
       config.outgoingPort ||
@@ -49,6 +49,10 @@ module.exports = function (config) {
   if (config.autoRelay) {
     const emailAddress = typeof config.autoRelay === 'string' ? config.autoRelay : null
     mailserver.setAutoRelayMode(true, config.autoRelayRules, emailAddress)
+  }
+
+  if (config.mailDirectory) {
+    mailserver.loadMailsFromDirectory()
   }
 
   if (!config.disableWeb) {

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -116,7 +116,7 @@ function handleDataStream (stream, session, callback) {
 /**
  * Delete everything in the mail directory
  */
-function clearMailDir() {
+function clearMailDir () {
   fs.readdir(mailServer.mailDir, function (err, files) {
     if (err) throw err
 
@@ -132,7 +132,7 @@ function clearMailDir() {
  * Create mail directory
  */
 
-function createMailDir() {
+function createMailDir () {
   if (!fs.existsSync(path.dirname(mailServer.mailDir))) {
     fs.mkdirSync(path.dirname(mailServer.mailDir))
     logger.log('Mail directory created at %s', path.dirname(mailServer.mailDir))
@@ -349,7 +349,7 @@ mailServer.deleteEmail = function (id, done) {
     if (err) {
       logger.error(err)
     } else {
-      eventEmitter.emit('delete', {id: id, index: emailIndex})
+      eventEmitter.emit('delete', { id: id, index: emailIndex })
     }
   })
 
@@ -492,7 +492,7 @@ mailServer.loadMailsFromDirectory = function () {
                 streamAttachments: true
               })
               logger.log('Restore mail %s', idMail)
-              var envelope = {from: '', to: '', host: 'undefined', remoteAddress: 'undefined'}
+              var envelope = { from: '', to: '', host: 'undefined', remoteAddress: 'undefined' }
               parseStream.on('from', function (from) {
                 envelope.from = from
               })

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -480,6 +480,7 @@ mailServer.loadMailsFromDirectory = function () {
     if (err) {
       logger.error('Error during reading of the mailDir %s', persistencePath)
     } else {
+      store.length = 0
       files.forEach(function (file) {
         var filePath = persistencePath + '/' + file
         if (path.parse(file).ext === '.eml') {

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -476,22 +476,36 @@ mailServer.getEmailEml = function (id, done) {
 
 mailServer.loadMailsFromDirectory = function () {
   var persistencePath = fs.realpathSync(mailServer.mailDir)
-  store.length = 0
   fs.readdir(persistencePath, function (err, files) {
     if (err) {
       logger.error('Error during reading of the mailDir %s', persistencePath)
     } else {
       files.forEach(function (file) {
         var filePath = persistencePath + '/' + file
-        fs.readFile(filePath, 'utf8', function (err, data) {
-          if (err) {
-            logger.error('Error during reading of the file %s', filePath)
-          } else {
-            var mail = JSON.parse(data)
-            logger.log('Restore mail %s', mail.id)
-            store.push(mail)
-          }
-        })
+        if (path.parse(file).ext === '.eml') {
+          fs.readFile(filePath, 'utf8', function (err, data) {
+            if (err) {
+              logger.error('Error during reading of the file %s', filePath)
+            } else {
+              var idMail = path.parse(file).name
+              var parseStream = new MailParser({
+                streamAttachments: true
+              })
+              logger.log('Restore mail %s', idMail)
+              var envelope = {from: '', to: '', host: 'undefined', remoteAddress: 'undefined'}
+              parseStream.on('from', function (from) {
+                envelope.from = from
+              })
+              parseStream.on('to', function (to) {
+                envelope.to = to
+              })
+              parseStream.on('end', saveEmail.bind(null, idMail, envelope))
+              parseStream.on('attachment', saveAttachment.bind(null, idMail))
+              parseStream.write(data)
+              parseStream.end()
+            }
+          })
+        }
       })
     }
   })

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -52,7 +52,7 @@ function saveEmail (id, envelope, mailObject) {
   var object = clone(mailObject)
 
   object.id = id
-  object.time = new Date()
+  object.time = mailObject.date ? mailObject.date : new Date()
   object.read = false
   object.envelope = envelope
   object.source = path.join(mailServer.mailDir, id + '.eml')

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -20,7 +20,7 @@ const stripTags = require('strip-tags')
 const defaultPort = 1025
 const defaultHost = '0.0.0.0'
 const store = []
-const tempDir = path.join(os.tmpdir(), 'maildev', process.pid.toString())
+const defaultMailDir = path.join(os.tmpdir(), 'maildev', process.pid.toString())
 const eventEmitter = new events.EventEmitter()
 
 /**
@@ -55,7 +55,7 @@ function saveEmail (id, envelope, mailObject) {
   object.time = new Date()
   object.read = false
   object.envelope = envelope
-  object.source = path.join(tempDir, id + '.eml')
+  object.source = path.join(mailServer.mailDir, id + '.eml')
 
   store.push(object)
 
@@ -72,10 +72,10 @@ function saveEmail (id, envelope, mailObject) {
 
 // Save an attachment
 function saveAttachment (id, attachment) {
-  if (!fs.existsSync(path.join(tempDir, id))) {
-    fs.mkdirSync(path.join(tempDir, id))
+  if (!fs.existsSync(path.join(mailServer.mailDir, id))) {
+    fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
-  var output = fs.createWriteStream(path.join(tempDir, id, attachment.contentId))
+  var output = fs.createWriteStream(path.join(mailServer.mailDir, id, attachment.contentId))
   attachment.stream.pipe(output)
 }
 
@@ -89,7 +89,7 @@ function createSaveStream (id, emailData) {
 }
 
 function createRawStream (id) {
-  return fs.createWriteStream(path.join(tempDir, id + '.eml'))
+  return fs.createWriteStream(path.join(mailServer.mailDir, id + '.eml'))
 }
 
 function handleDataStream (stream, session, callback) {
@@ -114,15 +114,14 @@ function handleDataStream (stream, session, callback) {
 }
 
 /**
- * Delete everything in the temp folder
+ * Delete everything in the mail directory
  */
-
-function clearTempFolder () {
-  fs.readdir(tempDir, function (err, files) {
+function clearMailDir() {
+  fs.readdir(mailServer.mailDir, function (err, files) {
     if (err) throw err
 
     files.forEach(function (file) {
-      rimraf(path.join(tempDir, file), function (err) {
+      rimraf(path.join(mailServer.mailDir, file), function (err) {
         if (err) throw err
       })
     })
@@ -130,23 +129,18 @@ function clearTempFolder () {
 }
 
 /**
- * Create temp folder
+ * Create mail directory
  */
 
-function createTempFolder () {
-  if (fs.existsSync(tempDir)) {
-    clearTempFolder()
-    return
+function createMailDir() {
+  if (!fs.existsSync(path.dirname(mailServer.mailDir))) {
+    fs.mkdirSync(path.dirname(mailServer.mailDir))
+    logger.log('Mail directory created at %s', path.dirname(mailServer.mailDir))
   }
 
-  if (!fs.existsSync(path.dirname(tempDir))) {
-    fs.mkdirSync(path.dirname(tempDir))
-    logger.log('Temporary directory created at %s', path.dirname(tempDir))
-  }
-
-  if (!fs.existsSync(tempDir)) {
-    fs.mkdirSync(tempDir)
-    logger.log('Temporary directory created at %s', tempDir)
+  if (!fs.existsSync(mailServer.mailDir)) {
+    fs.mkdirSync(mailServer.mailDir)
+    logger.log('Mail directory created at %s', mailServer.mailDir)
   }
 }
 
@@ -154,7 +148,7 @@ function createTempFolder () {
  * Create and configure the mailserver
  */
 
-mailServer.create = function (port, host, user, password, hideExtensions) {
+mailServer.create = function (port, host, mailDir, user, password, hideExtensions) {
   const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
   const smtpServerConfig = Object.assign({
     onAuth: smtpHelpers.createOnAuthCallback(user, password),
@@ -168,8 +162,8 @@ mailServer.create = function (port, host, user, password, hideExtensions) {
 
   smtp.on('error', mailServer.onSmtpError)
 
-  // Setup temp folder for attachments
-  createTempFolder()
+  mailServer.mailDir = mailDir || defaultMailDir
+  createMailDir()
 
   mailServer.port = port || defaultPort
   mailServer.host = host || defaultHost
@@ -280,7 +274,7 @@ mailServer.getRawEmail = function (id, done) {
   mailServer.getEmail(id, function (err, email) {
     if (err) return done(err)
 
-    done(null, fs.createReadStream(path.join(tempDir, id + '.eml')))
+    done(null, fs.createReadStream(path.join(mailServer.mailDir, id + '.eml')))
   })
 }
 
@@ -351,16 +345,16 @@ mailServer.deleteEmail = function (id, done) {
   }
 
   // delete raw email
-  fs.unlink(path.join(tempDir, id + '.eml'), function (err) {
+  fs.unlink(path.join(mailServer.mailDir, id + '.eml'), function (err) {
     if (err) {
       logger.error(err)
     } else {
-      eventEmitter.emit('delete', { id: id, index: emailIndex })
+      eventEmitter.emit('delete', {id: id, index: emailIndex})
     }
   })
 
   if (email.attachments) {
-    rimraf(path.join(tempDir, id), function (err) {
+    rimraf(path.join(mailServer.mailDir, id), function (err) {
       if (err) throw err
     })
   }
@@ -379,7 +373,7 @@ mailServer.deleteEmail = function (id, done) {
 mailServer.deleteAllEmail = function (done) {
   logger.warn('Deleting all email')
 
-  clearTempFolder()
+  clearMailDir()
   store.length = 0
   eventEmitter.emit('delete', { id: 'all' })
 
@@ -406,7 +400,7 @@ mailServer.getEmailAttachment = function (id, filename, done) {
       return done(new Error('Attachment not found'))
     }
 
-    done(null, match.contentType, fs.createReadStream(path.join(tempDir, id, match.contentId)))
+    done(null, match.contentType, fs.createReadStream(path.join(mailServer.mailDir, id, match.contentId)))
   })
 }
 
@@ -476,6 +470,29 @@ mailServer.getEmailEml = function (id, done) {
 
     var filename = email.id + '.eml'
 
-    done(null, 'message/rfc822', filename, fs.createReadStream(path.join(tempDir, id + '.eml')))
+    done(null, 'message/rfc822', filename, fs.createReadStream(path.join(mailServer.mailDir, id + '.eml')))
+  })
+}
+
+mailServer.loadMailsFromDirectory = function () {
+  var persistencePath = fs.realpathSync(mailServer.mailDir)
+  store.length = 0
+  fs.readdir(persistencePath, function (err, files) {
+    if (err) {
+      logger.error('Error during reading of the mailDir %s', persistencePath)
+    } else {
+      files.forEach(function (file) {
+        var filePath = persistencePath + '/' + file
+        fs.readFile(filePath, 'utf8', function (err, data) {
+          if (err) {
+            logger.error('Error during reading of the file %s', filePath)
+          } else {
+            var mail = JSON.parse(data)
+            logger.log('Restore mail %s', mail.id)
+            store.push(mail)
+          }
+        })
+      })
+    }
   })
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -2,6 +2,7 @@ module.exports.options = [
   // flag, environment variable, description, default value, function
   ['-s, --smtp <port>', 'MAILDEV_SMTP_PORT', 'SMTP port to catch emails', '1025'],
   ['-w, --web <port>', 'MAILDEV_WEB_PORT', 'Port to run the Web GUI', '1080'],
+  ['--mail-directory <path>', 'Directory for persisting mails'],
   ['--https', 'MAILDEV_HTTPS', 'Switch from http to https protocol', false],
   ['--https-key <file>', 'MAILDEV_HTTPS_KEY', 'The file path to the ssl private key'],
   ['--https-cert <file>', 'MAILDEV_HTTPS_CERT', 'The file path to the ssl cert file'],
@@ -24,7 +25,9 @@ module.exports.options = [
     'MAILDEV_HIDE_EXTENSIONS',
     'Comma separated list of SMTP extensions to NOT advertise (SMTPUTF8, PIPELINING, 8BITMIME)',
     [],
-    function (val) { return val.split(',') }
+    function (val) {
+      return val.split(',')
+    }
   ],
   ['-o, --open', null, 'Open the Web GUI after startup'],
   ['-v, --verbose'],

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -128,5 +128,9 @@ module.exports = function (app, mailserver, basePathname) {
     res.json(true)
   })
 
+  router.get('/reloadMailsFromDirectory', function (req, res) {
+    mailserver.loadMailsFromDirectory()
+    res.json(true)
+  })
   app.use(basePathname, router)
 }


### PR DESCRIPTION
This PR add some new features :

- Persistence for mail can be used by using the option --mail-directory
- Can be used to mount a volume in a kubernetes/docker environment
- At startup reload mails in memory from the directory specified
- Add a new endpoint to force reload mail in memory from directory

Inspered by this PR https://github.com/maildev/maildev/pull/280 

Can address this issues :

- https://github.com/maildev/maildev/issues/44
- https://github.com/maildev/maildev/issues/299

The last point is usefull to adresses this issues : https://github.com/maildev/maildev/pull/237 & https://github.com/maildev/maildev/issues/127 cause you can add an external rules for purging mail in directory (ie: cron find file aged more than X days, delete it & trigger reload mail)

For a preview of usage for this feature in a kubernetes environnement with helm, you can check this repo : https://github.com/cnieg/helm-charts/tree/master/charts/maildev