### PR TITLE
Remove session.io cookie usage

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -111,7 +111,7 @@ web.start = function (port, host, mailserver, user, password, basePathname, secu
 
   routes(app, mailserver, basePathname)
 
-  io.attach(web.server)
+  io.attach(web.server, { cookie: false })
   io.on('connection', webSocketConnection(mailserver))
 
   port = port || 1080


### PR DESCRIPTION
While using maildev, the console gets plagued with the
"Some cookies are misusing the recommended 'sameSite' attribute" message.

This occurs because Chrome/Firefox enforces the secure flag with the SameSite=None attribute.
(Refer this [wikiloop-battlefield issue](https://github.com/google/wikiloop-battlefield/issues/239)).

Since this cookie [isn't used for anything](https://github.com/socketio/socket.io/issues/2276), i've disabled it.