### PR TITLE
docs: Fix target ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
 For a guide for usage with Docker,
 [checkout the docs](https://github.com/maildev/maildev/blob/master/docs/docker.md).
 
-    $ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
+    $ docker run -p 1080:80 -p 1025:25 maildev/maildev
 
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 


### PR DESCRIPTION
The SMTP and HTTP port within the docker container must be 25 and 80 respectively. @jovanmaric wrong merge conflict resolution in 1fe0e9f1184a6a0adefae36c23fb044c518a82c2?