### PR TITLE
Correct docker run ports in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
 For a guide for usage with Docker,
 [checkout the docs](https://github.com/maildev/maildev/blob/master/docs/docker.md).
 
-    $ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
+    $ docker run -p 1080:80 -p 1025:25 maildev/maildev
 
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 


### PR DESCRIPTION
Fixes the readme so that the container ports are using the default ports of 80, and 25, but the host ports are still 1080 and 1025.

Fixes #307 