### PR TITLE
docker: add curl to final image for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --no-cache curl \
 # Prod
 FROM base as prod
 
+RUN apk add --no-cache curl
+
 USER node
 WORKDIR /home/node
 


### PR DESCRIPTION
healthchecks have been failing because the final image did not install curl