### PR TITLE
Respect basePathname in auth middleware

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,13 +1,16 @@
 'use strict'
 
+const path = require('path')
+
 /**
  * MailDev - auth.js
  */
 
-module.exports = function (user, password) {
+module.exports = function (user, password, basePathname) {
+  var healthPath = path.posix.join(basePathname, '/healthz')
   return function (req, res, next) {
     // allow health checks without auth
-    if (req.path === '/healthz') {
+    if (req.path === healthPath) {
       return next()
     }
 

--- a/lib/web.js
+++ b/lib/web.js
@@ -95,12 +95,12 @@ web.start = function (port, host, mailserver, user, password, basePathname, secu
     web.server = http.createServer(app)
   }
 
-  if (user && password) {
-    app.use(auth(user, password))
-  }
-
   if (!basePathname) {
     basePathname = '/'
+  }
+
+  if (user && password) {
+    app.use(auth(user, password, basePathname))
   }
 
   io = socketio({ path: path.posix.join(basePathname, '/socket.io') })

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -5,12 +5,12 @@ const auth = require('../lib/auth')
 
 describe('auththentication middleware', () => {
   it('should return a function', () => {
-    const middleware = auth('user', 'password')
+    const middleware = auth('user', 'password', '/')
     expect(middleware).toBeA(Function)
   })
 
   it('should return Unauthorized without authorization headers', () => {
-    const middleware = auth('user', 'password')
+    const middleware = auth('user', 'password', '/')
     const fakeRequest = {
       headers: {}
     }
@@ -31,7 +31,7 @@ describe('auththentication middleware', () => {
   })
 
   it('should return Unauthorized with incorrect authorization username and password', () => {
-    const middleware = auth('user', 'password')
+    const middleware = auth('user', 'password', '/')
     const fakeRequest = {
       headers: {
         authorization: `Basic ${Buffer.from('not:correct').toString('base64')}`
@@ -54,7 +54,7 @@ describe('auththentication middleware', () => {
   })
 
   it('should call next function with valid username and password', (done) => {
-    const middleware = auth('user', 'password')
+    const middleware = auth('user', 'password', '/')
     const fakeRequest = {
       headers: {
         authorization: `Basic ${Buffer.from('user:password').toString('base64')}`
@@ -70,9 +70,24 @@ describe('auththentication middleware', () => {
   })
 
   it('should call next function for health checks', (done) => {
-    const middleware = auth('user', 'password')
+    const middleware = auth('user', 'password', '/')
     const fakeRequest = {
       path: '/healthz',
+      headers: { }
+    }
+    const fakeResponse = {
+      statusCode: null,
+      setHeader: function () {},
+      send: function () {}
+    }
+
+    middleware(fakeRequest, fakeResponse, done)
+  })
+
+  it('should call next function for health checks with basePathname', (done) => {
+    const middleware = auth('user', 'password', '/maildev')
+    const fakeRequest = {
+      path: '/maildev/healthz',
       headers: { }
     }
     const fakeResponse = {


### PR DESCRIPTION
The healthz route is prefixed by basePathname but the check that skips
authentication for the health route always checks for the /healthz path
without prefix.

The healthz path should also be available without authentication when a
basePathname is defined.