### PR TITLE
fix(css): update css to allow for tall emails to be displayed fully

### DIFF
--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -94,7 +94,9 @@ a:focus {
 
 .main-container {
     @include flex(1 70%);
-    overflow-y: scroll;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .sidebar-header {
@@ -179,6 +181,9 @@ a:focus {
 
 .email-container {
     padding-top: $toolbarHeight;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .email-toolbar {
@@ -189,6 +194,7 @@ a:focus {
 .email-content {
     position: inherit; z-index: 1;
     margin: 1em; padding-top: $toolbarHeight;
+    flex-grow: 1;
 }
 
 
@@ -435,7 +441,7 @@ code {
 }
 
 .preview-iframe {
-    border:0; width:100%; min-height:600px;
+    border:0; height: 100%; width:100%; min-height:600px;
     position: relative; // set position for resize rendering issue
 }
 


### PR DESCRIPTION
## bug
Currently if you have a very tall email it gets clipped in the email html preview:

<details>
<summary>clipped email preview</summary>

![image](https://user-images.githubusercontent.com/66273043/101955982-a3e7e300-3bb3-11eb-8fc0-fbd397ef7457.png)

</details>

## fix
I updated some of the css so that these tall emails take up the entire screen real estate.

<details>
<summary>after</summary>

![image](https://user-images.githubusercontent.com/66273043/101955965-9cc0d500-3bb3-11eb-92be-7b3d95e867e5.png)

</details>
