### PR TITLE
switch to Github actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test
+    - run: bash <(curl -s https://codecov.io/bash) # Upload to Codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "stable"
-  - "10"
-  - "8"
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-notifications:
-  email: false


### PR DESCRIPTION
* Removes Travis
* Add Github Actions
* https://github.com/madflow/maildev/actions/runs/427974910

As far as I can see the Travis test are currently not visible/running. Github actions should be - and do not require a second vendor.