### PR TITLE
Fix docker port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
 For a guide for usage with Docker,
 [checkout the docs](https://github.com/maildev/maildev/blob/master/docs/docker.md).
 
-    $ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
+    $ docker run -p 1080:80 -p 1025:25 maildev/maildev
 
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
 For a guide for usage with Docker,
 [checkout the docs](https://github.com/maildev/maildev/blob/master/docs/docker.md).
 
-    $ docker run -p 1080:80 -p 1025:25 maildev/maildev
+    $ docker run -p 8080:80 -p 1025:25 maildev/maildev
 
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 


### PR DESCRIPTION
Docker container exposes port 25 and port 80 to be used for SMTP and Web client respectively and not port 1025 and 1080.

Therefore I have updated the command snippet to bind host ports 1025 and 8080 to container port 25 and 80 respectively.

Note: I used port 8080 instead of 1080 because binding to port 1080 in some systems will require administrative privilege