### PR TITLE
BCC support

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -168,6 +168,7 @@
 
         <script src="scripts/app.js"></script>
         <script src="scripts/services.js"></script>
+        <script src="scripts/components/address.js"></script>
         <script src="scripts/controllers/main.js"></script>
         <script src="scripts/controllers/item.js"></script>
 

--- a/app/scripts/components/address.js
+++ b/app/scripts/components/address.js
@@ -1,0 +1,15 @@
+/* global app */
+
+/**
+ * This compoonent displays an address either with or without a name.
+ */
+
+app.directive('appAddress', function () {
+  return {
+    restrict: 'E',
+    scope: {
+      addr: '=address'
+    },
+    templateUrl: 'views/address.html'
+  }
+})

--- a/app/views/address.html
+++ b/app/views/address.html
@@ -1,0 +1,3 @@
+<span class="address"><span 
+  ng-if="addr.name"><span class="address-name">{{addr.name}}</span> <span class="address-address">&lt;{{addr.address}}&gt;</span></span><span 
+  ng-if="!addr.name"><span class="address-name">{{addr.address}}</span></span></span>

--- a/app/views/item.html
+++ b/app/views/item.html
@@ -223,7 +223,33 @@
 </ul>
 
 
-
+<div class="email-meta">
+  <div class="subject">{{item.subject}}</div>
+  <div class="row from">
+    <div class="description">From:</div>
+    <div class="description-value">
+      <app-address ng-repeat="a in item.from" address="a"></app-address>
+    </div>
+  </div>
+  <div class="row to">
+    <div class="description">To:</div>
+    <div class="description-value">
+      <app-address ng-repeat="a in item.to" address="a"></app-address>
+    </div>
+  </div>
+  <div ng-if="item.cc.length" class="row cc">
+    <div class="description">Cc:</div>
+    <div class="description-value">
+      <app-address ng-repeat="a in item.cc" address="a"></app-address>
+    </div>
+  </div>
+  <div ng-if="item.calculatedBcc.length" class="row calculated-bcc">
+    <div class="description">Bcc:</div>
+    <div class="description-value">
+      <app-address ng-repeat="a in item.calculatedBcc" address="a"></app-address>
+    </div>
+  </div>
+</div>
 
 
 

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -731,6 +731,85 @@ body.dark-theme {
 
 }
 
+.email-meta {
+    box-sizing: border-box;
+    width: 100%;
+    background-color: white;
+    background: lighten($brand, 38);
+    border-bottom: 1px solid lighten($brand, 28);
+    margin: 0;
+    padding: .5em 1em;
+    font-size: 14px;
+
+    .row {
+        @include display-flex();
+        flex-flow: row nowrap;
+
+        @media (max-width: 1100px) {
+            flex-wrap: wrap;
+            flex-direction: column;
+            & + .row {
+                margin-top: .5em;
+            }
+        }
+    }
+
+    .description {
+        flex-basis: 5em;
+        flex-shrink: 0; 
+        display: inline-block;
+        text-align: right;
+        margin-right: .25em;
+        color: desaturate(darken($brand, 12), 20);
+
+        @media (max-width: 1100px) {
+            text-align: left;
+            flex-basis: 0;
+            margin-right: 0;
+        }
+    }
+
+    .description-value {
+        flex-grow: 1;
+    }
+
+    .subject {
+        font-size: 20px;
+        margin-bottom: .5em;
+    }
+
+
+    .address .address-address {
+        color: rgba(lighten(black, 25), .40);
+    }
+    .address .address-name {
+        color: lighten(black, 30);
+    }
+
+    app-address + app-address::before {
+        content: ', ';
+    }
+
+
+    body.dark-theme & {
+        background-color: darken($brand, 28);
+        border-bottom-color: darken($brand, 18);
+        color: white;
+
+        .description {
+            color: desaturate(lighten($brand, 12), 20);
+        }
+
+        .address .address-address {
+            color: rgba(darken(white, 40), .65);
+        }
+        .address .address-name {
+            color: darken(white, 30);
+        }
+    }
+
+}
+
 
 .dropdown-container {
     position: relative;

--- a/lib/helpers/bcc.js
+++ b/lib/helpers/bcc.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const bccHelpers = module.exports = {}
+
+/**
+ * Filter out bcc addresses out of recipients.
+ */
+bccHelpers.calculateBcc = function (recipients, to, cc) {
+  cc = cc.slice()
+  to = to.slice()
+  const containsAddress = (as, a) => as.indexOf(a) !== -1
+  const removeAddress = (as, a) => {
+    const i = as.indexOf(a)
+    if (i !== -1) as.splice(i, 1)
+  }
+
+  const bccAddresses = []
+  for (const address of recipients) {
+    if (containsAddress(cc, address)) {
+      removeAddress(cc, address)
+      continue
+    }
+    if (containsAddress(to, address)) {
+      removeAddress(to, address)
+      continue
+    }
+    bccAddresses.push({ address, name: '' })
+  }
+  return bccAddresses
+}

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -14,6 +14,7 @@ const rimraf = require('rimraf')
 const utils = require('./utils')
 const logger = require('./logger')
 const smtpHelpers = require('./helpers/smtp')
+const { calculateBcc } = require('./helpers/bcc')
 const outgoing = require('./outgoing')
 const stripTags = require('strip-tags')
 
@@ -62,6 +63,12 @@ function saveEmailToStore (id, isRead = false, envelope, parsedEmail) {
   serialized.size = stat.size
   serialized.sizeHuman = utils.formatBytes(stat.size)
   serialized.attachments = serializedAttachments
+  const onlyAddress = xs => (xs || []).map(x => x.address)
+  serialized.calculatedBcc = calculateBcc(
+    onlyAddress(envelope.to),
+    onlyAddress(parsedEmail.to),
+    onlyAddress(parsedEmail.cc)
+  )
 
   store.push(serialized)
 

--- a/test/bccHelpers.test.js
+++ b/test/bccHelpers.test.js
@@ -1,0 +1,48 @@
+/* global describe, it */
+'use strict'
+const expect = require('expect')
+const { calculateBcc } = require('../lib/helpers/bcc')
+
+describe('[bcc helpers]', () => {
+  describe('calculateBcc', () => {
+    it('works with empty addresses', () => {
+      const actual = calculateBcc([], [], [])
+
+      expect(actual).toEqual([])
+    })
+
+    it('does not modify input arrays', () => {
+      const recipients = ['x@y', 'a@b']
+      const to = ['a@b']
+      const cc = ['x@y']
+      calculateBcc(recipients, to, cc)
+
+      expect(recipients).toEqual(['x@y', 'a@b'])
+      expect(to).toEqual(['a@b'])
+      expect(cc).toEqual(['x@y'])
+    })
+
+    describe('calculates bcc as the difference of (recipients - to - cc)', () => {
+      it('empty when all recipients are consumed', () => {
+        const actual = calculateBcc(['x@y', 'a@b'], ['a@b'], ['x@y'])
+
+        expect(actual).toEqual([])
+      })
+
+      it('when same recipient is in TO, CC and BCC', () => {
+        const actual = calculateBcc(['a@b', 'a@b', 'a@b'], ['a@b'], ['a@b'])
+
+        expect(actual).toEqual([{ address: 'a@b', name: '' }])
+      })
+
+      it('comparison of addresses is case sensitive', () => {
+        const actual = calculateBcc(
+          ['bodhi@gmail.com', 'johnny.first@fbi.gov', 'Johnny.first@fbi.gov'],
+          ['Johnny.first@fbi.gov'],
+          ['bodhi@gmail.com'])
+
+        expect(actual).toEqual([{ address: 'johnny.first@fbi.gov', name: '' }])
+      })
+    })
+  })
+})


### PR DESCRIPTION
As maildev is primarily a debugging tool we want to validate the correctness of TO, CC and BCC as well.

See #233 

## Possible solutions
- multiply the emails for each recipient
- show cc and bcc addresses in the preview

Duplicating emails won't help debugging and may make it even worse. So we went for the "show in preview" option. 


## Implementation

Bcc should not be contained in the mail source. Otherwise it wouldn't be a "blind" copy as the recipients could see the blind copy recipients. Every recipient (to, cc, bcc) should be part of the `RCPT` though. So from my understanding and the insight of this [Mailtrap article](https://mailtrap.io/blog/cc-bcc-in-smtp/) bcc should be `allRecipients - to - cc`. This calculated bcc is what I implemented and added to the stored parsed email.

On the GUI side I found that it's actually hard to validate the recipients in maildev. Besides the headers this information isn't really shown in detail. To fix the missing details I implemented a panel below the email toolbar to show information. I'm not quite sure if this panel meets your UI expectations but in my opinion something like that would be a great addition to the project. This way the user can easily debug who should've received the mail.

![image](https://user-images.githubusercontent.com/923638/140505018-4949f296-98a0-4357-9d12-46c7b6947e2e.png)
![image](https://user-images.githubusercontent.com/923638/140505074-e76bfb0c-2bdf-4674-9c53-1da8d377d4c3.png)

## Preview

I built a docker image as a preview with the recipients/bcc support added by this pull requests. You can find it at [delbertooo/maildev-bcc](https://registry.hub.docker.com/r/delbertooo/maildev-bcc).