### PR TITLE
Add support for IMAP, POP3 and SMTP with Authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Base
 FROM node:10-alpine as base
-MAINTAINER "Dan Farrelly <daniel.j.farrelly@gmail.com>"
+LABEL org.opencontainers.image.authors="Dan Farrelly <daniel.j.farrelly@gmail.com>"
 
 ENV NODE_ENV production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,39 @@ RUN npm install \
 # Prod
 FROM base as prod
 
-USER node
-WORKDIR /home/node
+RUN apk update \
+  && apk add dumb-init \
+  && apk add dovecot dovecot-submissiond \
+  && apk add sudo
+
+# Avoid using encryption for docker setup.
+RUN rm -f /etc/dovecot/conf.d/10-ssl.conf
+
+# Add custom configuration file for submission (SMTP)
+# with dovecot using the same username and password as
+# for imap. This will forward to maildev.
+COPY dovecot/20-submission.conf /etc/dovecot/conf.d/20-submission.conf
+COPY dovecot/11-custom-logging.conf /etc/dovecot/conf.d/11-custom-logging.conf
+COPY dovecot/11-custom-auth.conf /etc/dovecot/conf.d/11-custom-auth.conf
+# Add a hardcoded list of users with passwords for smtp and imap auth.
+COPY dovecot/users /etc/dovecot/users
 
 COPY --chown=node:node . /home/node
 COPY --chown=node:node --from=build /root/node_modules /home/node/node_modules
 
-EXPOSE 1080 1025
+# Initialize the Maildir directory with the required folders
+# for Dovecot to recognize it as a valid Maildir directory.
+RUN mkdir /home/node/Maildir && \
+  mkdir /home/node/Maildir/cur && \
+  mkdir /home/node/Maildir/new && \
+  mkdir /home/node/Maildir/tmp && \
+  chown -R node /home/node/Maildir
 
-ENTRYPOINT ["/home/node/bin/maildev"]
-CMD ["--web", "1080", "--smtp", "1025"]
+EXPOSE 80 25 110 143 587
+
+COPY run.sh /run.sh
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/bin/sh", "/run.sh"]
 
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -O - http://localhost:1080/healthz || exit 1
+  CMD wget -O - http://localhost:80/healthz || exit 1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 **MailDev** is a simple way to test your project's generated emails during development with an easy to use web interface that runs on your machine. Built on top of [Node.js](http://www.nodejs.org).
+It also contains a [POP3](https://en.wikipedia.org/wiki/POP3) and [IMAP](https://en.wikipedia.org/wiki/IMAP) server, thanks to [dovecot](https://www.dovecot.org/).
 
 ![MailDev Screenshot](https://github.com/maildev/maildev/blob/gh-pages/images/screenshot-2021-01-03.png?raw=true)
 
@@ -89,6 +90,46 @@ Example:
               --outgoing-secure \
               --outgoing-user 'you@gmail.com' \
               --outgoing-pass '<pass>'
+
+## IMAP and POP
+
+To use IMAP and/or POP3, just point your prefered to Mail Client to
+
+- host: `localhost`
+- user: `node`
+- password: `password`
+- port:
+  - 110 (POP3)
+  - 143 (IMAP)
+
+Make sure you disable any kind of encryption
+
+## SMTP (Submission with Password)
+
+To test authenticated submission from a command line, you can use the netcat command `nc`.
+Here is an example usage:
+```
+nc localhost 1587 <<EOS
+EHLO hostname
+AUTH PLAIN AG5vZGUAcGFzc3dvcmQ=
+MAIL FROM:<john@doe.com>
+RCPT TO:<jane@doe.com>
+DATA
+From: John Doe <john@doe.com>
+To: Jane Doe<jane@doe.com>
+Date: Tue, 15 Jan 2008 16:02:43 -0500
+Subject: Testing Authenticated SMTP submission
+
+Find this email in the web interface at http://localhost:1080
+and delete it.
+.
+QUIT
+EOS
+```
+
+Notice that the `AUTH PLAIN` command uses the base encoded username and password,
+generated with the command `echo -en "\0node\0password" | base64`.
+
 
 ### Auto relay mode
 
@@ -205,6 +246,7 @@ To run the test suite:
 and [mailparser](https://github.com/nodemailer/mailparser).
 Many thanks to Andris as his projects are the backbone of this app and to
 [MailCatcher](http://mailcatcher.me/) for the inspiration.
+[dovecot](https://www.dovecot.org/) for the [POP3](https://en.wikipedia.org/wiki/POP3) and [IMAP](https://en.wikipedia.org/wiki/IMAP) support
 
 Additionally, thanks to all the awesome [contributors](https://github.com/maildev/maildev/graphs/contributors)
 to the project.

--- a/dovecot/11-custom-auth.conf
+++ b/dovecot/11-custom-auth.conf
@@ -1,0 +1,8 @@
+# Enable plain text login without encryption (TLS)
+disable_plaintext_auth = no
+
+# Enable plain text login.
+# Using the AUTH PLAIN $base64EncodedUsernameAndCredentials
+# Generated from the command line with
+#   echo -en "\0node\0password"|base64
+auth_mechanisms = plain

--- a/dovecot/11-custom-logging.conf
+++ b/dovecot/11-custom-logging.conf
@@ -1,0 +1,9 @@
+# Log to console when running in docker
+log_path = /dev/stderr
+
+# Uncomment all of the following to debug when developing.
+#auth_verbose = yes
+#auth_debug = yes
+#auth_debug_passwords = yes
+#mail_debug = yes
+#verbose_ssl = yes

--- a/dovecot/20-submission.conf
+++ b/dovecot/20-submission.conf
@@ -1,0 +1,9 @@
+protocols = submission
+
+protocol submission {
+	ssl = no
+}
+
+submission_relay_host = localhost
+submission_relay_port = 25
+submission_relay_trusted = yes

--- a/dovecot/users
+++ b/dovecot/users
@@ -1,0 +1,1 @@
+node:{MD5-CRYPT}$1$2nVPHZ5s$rwQO7Mc/nqhfM25PKw7O6.:1000:1000::/home/node:/bin/false::

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,16 @@
+#!/bin/ash
+#
+# Dovecot will bind to privileged ports below 1014 and drop privileges
+# before accessing the Maildir
+/usr/sbin/dovecot && \
+echo "Dovecot listening to POP3(110), IMAP(143), SMTP(587)" &
+# Run maildev as the node user, not root.
+# Since this container does nothing else than running an smtp server
+# running as a user instead of root may be of some, discussable, security benefit.
+# Prior to Docker 20.10 it was prevented from listening to ports 80 and 25,
+# and therefore the ports 1080 and 1025 was chosen.
+# From Docker 20.10 it is allowed due to the default setting of
+#   docker run ... --sysctl net.ipv4.ip_unprivileged_port_start=0
+# Therefore listen to the default ports 80 for http and 25 for smtp.
+# Write mail to the home directory of the user, where Dovecot will find it.
+sudo -iu node /home/node/bin/maildev --web 80 --smtp 25 --mail-directory /home/node/Maildir


### PR DESCRIPTION
This PR adds dovecot with configuration for IMAP, POP3 and SMTP with authentication.

The Dovecot setup is pretty straight forward, without any ssl setup.
The added SMTP with authentication was to test our system with credentials for SMTP.

I did move the port from 1025 and 1080 to 25 and 80, as there is no longer a problem to bind to privileged ports
in docker, but I can revert that.

I use `dumb-init` to run both dovecot and `maildev`.

I've added some minimal documentation, and a CLI example of how to do SMTP with authentication.

This is inspired by the PR #209 , but is hopefully less intrusive by not moving around any js files.

This also fixes #166 .

I've published the packages - for testing - at `veridit/maildev` as we are using that for our own project.

To run locally and test one can try with `docker run --rm -it -p 1587:587 -p 1080:80 -p 1025:25 -p 1143:143 veridit/maildev`
