### PR TITLE
Fix docker port binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use MailDev with [Docker](https://www.docker.com/), you can use t
 For a guide for usage with Docker,
 [checkout the docs](https://github.com/maildev/maildev/blob/master/docs/docker.md).
 
-    $ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
+    $ docker run -p 1080:80 -p 1025:25 maildev/maildev
 
 For convenient use with Grunt, try [grunt-maildev](https://github.com/xavierpriour/grunt-maildev).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -13,13 +13,18 @@ If you don't have the image on your machine, Docker will pull it. Let's name
 it "maildev" and publish the interface on port `1080`:
 
 ```
-$ docker run -p 1080:1080 --name maildev maildev/maildev
+$ docker run -p 1080:80 --name maildev maildev/maildev
 ```
 
 Now the MailDev UI will be running at port `1080` on your virtual machine
 (or machine if you're running Linux). For example if your Docker host VM is
 running at `192.168.99.100`, you can head over to `http://192.168.99.100:1080`
-to visit the interface.
+to visit the interface. Additionally, if you want to expose the SMTP server to your host
+you can publish the interface e.g. on port `1025`:
+
+```
+$ docker run -p 1080:80 -p 1025:25 --name maildev maildev/maildev
+```
 
 Let's say you're using [nodemailer](https://github.com/nodemailer/nodemailer)
 in your Node.js app running in another container. Let's link your app's


### PR DESCRIPTION
Hey, thanks for creating maildev! I use it a lot for local development.

I encountered an issue with the docker command in the README and the docs. The server runs on port `25` and `80` within the container, but the README suggests binding port `1025` and `1080`. Therefore, the command doesn't work out of the box.

I hope the fix provided is valid for all systems and users, I tested it on Linux (5.10.89-1-MANJARO) with docker 20.10.12 (build e91ed5707e)