### PR TITLE
bugfix: update package.json declare that Node v12 or later is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "standard": "^16.0.4"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
According to @danjarvis  suggestion, update the node version dependencies of the package