### PR TITLE
Fix healthcheck checks hardcoded port, fixes #407

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,4 @@ ENV MAILDEV_WEB_PORT 1080
 ENV MAILDEV_SMTP_PORT 1025
 ENTRYPOINT ["bin/maildev"]
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -O - http://localhost:1080/healthz || exit 1
+  CMD wget -O - http://localhost:${MAILDEV_WEB_PORT}/healthz || exit 1


### PR DESCRIPTION
Fixes  Dockerfile HEALTHCHECK vs configuring the host/port for the web interface vs IPv4/IPv6

Fixes #407 