### PR TITLE
Fix crash when attachment with contentId containing /

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -94,7 +94,7 @@ function saveAttachment (id, attachment) {
     fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
   const output = fs.createWriteStream(
-    path.join(mailServer.mailDir, id, attachment.contentId)
+    path.join(mailServer.mailDir, id, encodeURIComponent(attachment.contentId))
   )
   attachment.stream.pipe(output)
 }
@@ -490,7 +490,7 @@ mailServer.getEmailAttachment = function (id, filename, done) {
     done(
       null,
       match.contentType,
-      fs.createReadStream(path.join(mailServer.mailDir, id, match.contentId))
+      fs.createReadStream(path.join(mailServer.mailDir, id, encodeURIComponent(match.contentId)))
     )
   })
 }


### PR DESCRIPTION
When an email is rec ivied with a `contentId` containing a slash `/` it fail with

```
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open '/tmp/maildev-244388/H7awAzl6/folder/image'
Emitted 'error' event on WriteStream instance at:
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/tmp/maildev-244388/H7awAzl6/folder/image'
}
```

I fixed it using `encodeURIComponent` when reading or writing to disk.

I also include a test case.