### PR TITLE
upgrade socket.io to fix CVE-2022-41940 and CVE-2022-2421

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM node:16-alpine as base
+FROM node:18-alpine as base
 ENV NODE_ENV production
 
 # Build

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nodemailer": "^6.7.2",
     "rimraf": "^3.0.2",
     "smtp-server": "3.11.0",
-    "socket.io": "4.4.1",
+    "socket.io": "4.6.0",
     "uue": "3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Ola,

this is just a minor update, upgrading socket.io version on package.json to 4.6.0, which fixes some vulnerabilities (CVE-2022-41940 and CVE-2022-2421 -- actually those were flagged in the package dependencies).

Tested locally and found no issues on the app behavior, but I honestly didn't go through the whole code to analyze the impact of this update.

Also, it'd be nice to update the dockerhub image -- there are several other CVEs that can be fixed with the latest node:16-alpine image (or another more up-to date node version as well, but the vulns were at the alpine image itself).

Currently there's only one vulnerability still listed for this image (based on AWS Inspector): CVE-2022-25881 - http-cache-semantics -- which is actually a core npm dependency (not the app's), still to check if a more up-to-date nodejs version would fix it (I might update this PR in case it does and maildev works good on node:18-alpine).

Thanks for the great project!