### PR TITLE
Dont sanitize target=_blank attributes on anchors.

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -300,7 +300,8 @@ mailServer.getEmail = function (id, done) {
       email.html = DOMPurify.sanitize(email.html, {
         WHOLE_DOCUMENT: true, // preserve html,head,body elements
         SANITIZE_DOM: false, // ignore DOM cloberring to preserve form id/name attributes
-        ADD_TAGS: ['link'] // allow link element to preserve external style sheets
+        ADD_TAGS: ['link'], // allow link element to preserve external style sheets
+        ADD_ATTR: ['target'] // Preserve explicit target attributes on links
       })
     }
     done(null, email)


### PR DESCRIPTION
Currently, when you have a link in your email, maildev removes "target=_blank" on anchors.
e.g.

`<a href="...." target="_blank" />` is sanitized into  `<a href="..." />`

This PR adds the "target" attribute to the allowed items.

Partially fixes: https://github.com/maildev/maildev/issues/457