### PR TITLE
The bottom content of the email is hidden because of the meta bar

### DIFF
--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -615,13 +615,15 @@ body.dark-theme {
 
 
 .email-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .email-content {
     box-sizing: border-box;
     z-index: 1;
-    height: calc(100vh - #{$toolbarHeight});
-    //border-top: 1px solid darken(white,10);
+    flex: 1;
 }
 
 .email-content-view {


### PR DESCRIPTION
There is a portion of the emails that we can't see because of the set height of `.email-content`

Here I just make a flex box of the entire column , set it to 100% of its container and say `.email-content` must grow inside the available space (all the space under the `.email-header` and `.email-meta`). then its content can still be scrolled but we can see the entire content of the email