### PR TITLE
Listen on IPv4 and IPv6 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Usage: maildev [options]
 | `--https`                        | `MAILDEV_HTTPS`            | Switch from http to https protocol                                                        |
 | `--https-key <file>`             | `MAILDEV_HTTPS_KEY`        | The file path to the ssl private key                                                      |
 | `--https-cert <file>`            | `MAILDEV_HTTPS_CERT`       | The file path to the ssl cert file                                                        |
-| `--ip <ip address>`              | `MAILDEV_IP`               | IP Address to bind SMTP service to                                                        |
+| `--ip <ip address>`              | `MAILDEV_IP`               | IP Address to bind SMTP service to, defaults to `::` (any IPv4/v6)                        |
 | `--outgoing-host <host>`         | `MAILDEV_OUTGOING_HOST`    | SMTP host for outgoing mail                                                               |
 | `--outgoing-port <port>`         | `MAILDEV_OUTGOING_PORT`    | SMTP port for outgoing mail                                                               |
 | `--outgoing-user <user>`         | `MAILDEV_OUTGOING_USER`    | SMTP user for outgoing mail                                                               |

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -23,7 +23,7 @@ const store = []
 const eventEmitter = new events.EventEmitter()
 
 const defaultPort = 1025
-const defaultHost = '0.0.0.0'
+const defaultHost = '::'
 const defaultMailDir = path.join(
   os.tmpdir(),
   `maildev-${process.pid.toString()}`

--- a/lib/options.js
+++ b/lib/options.js
@@ -6,7 +6,7 @@ module.exports.options = [
   ['--https', 'MAILDEV_HTTPS', 'Switch from http to https protocol', false],
   ['--https-key <file>', 'MAILDEV_HTTPS_KEY', 'The file path to the ssl private key'],
   ['--https-cert <file>', 'MAILDEV_HTTPS_CERT', 'The file path to the ssl cert file'],
-  ['--ip <ip address>', 'MAILDEV_IP', 'IP Address to bind SMTP service to', '0.0.0.0'],
+  ['--ip <ip address>', 'MAILDEV_IP', 'IP Address to bind SMTP service to', '::'],
   ['--outgoing-host <host>', 'MAILDEV_OUTGOING_HOST', 'SMTP host for outgoing emails'],
   ['--outgoing-port <port>', 'MAILDEV_OUTGOING_PORT', 'SMTP port for outgoing emails'],
   ['--outgoing-user <user>', 'MAILDEV_OUTGOING_USER', 'SMTP user for outgoing emails'],

--- a/lib/web.js
+++ b/lib/web.js
@@ -115,7 +115,7 @@ web.start = function (port, host, mailserver, user, password, basePathname, secu
   io.on('connection', webSocketConnection(mailserver))
 
   port = port || 1080
-  host = host || '0.0.0.0'
+  host = host || '::'
 
   web.server.listen(port, host)
 


### PR DESCRIPTION
Should fix #484 

Maildev currently listens on IPv4 only, which causes the healthcheck to fail with some Docker versions or custom daemon settings. Most dockerized apps that I've seen listen on both IPv4 and IPv6.

This should be documented as a breaking change to avoid unwanted exposure of Maildev in case someone has a particular config (for example a Docker daemon configured to use a public IPv6 block)