### PR TITLE
fix: File name injections via `Content-ID` header

### DIFF
--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -93,11 +93,8 @@ function saveAttachment (id, attachment) {
   if (!fs.existsSync(path.join(mailServer.mailDir, id))) {
     fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
-  const safeFileName = createHash('md5').update(attachment.contentId).digest('hex')
-    + '-'
-    + attachment.contentId.replace(/[:/\\]+/g, '-')
   const output = fs.createWriteStream(
-    path.join(mailServer.mailDir, id, safeFileName)
+    path.join(mailServer.mailDir, id, attachment.contentId)
   )
   attachment.stream.pipe(output)
 }

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -95,7 +95,7 @@ function saveAttachment (id, attachment) {
   }
   const safeFileName = createHash('md5').update(attachment.contentId).digest('hex')
     + '-'
-    + attachment.contentId.replace(/[:/]+/g, '-')
+    + attachment.contentId.replace(/[:/\\]+/g, '-')
   const output = fs.createWriteStream(
     path.join(mailServer.mailDir, id, safeFileName)
   )

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -93,8 +93,11 @@ function saveAttachment (id, attachment) {
   if (!fs.existsSync(path.join(mailServer.mailDir, id))) {
     fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
+  const safeFileName = createHash('md5').update(attachment.contentId).digest('hex')
+    + '-'
+    + attachment.contentId.replace(/[:/]+/g, '-')
   const output = fs.createWriteStream(
-    path.join(mailServer.mailDir, id, attachment.contentId)
+    path.join(mailServer.mailDir, id, safeFileName)
   )
   attachment.stream.pipe(output)
 }

--- a/vendor/mailparser-mit/lib/mailparser.js
+++ b/vendor/mailparser-mit/lib/mailparser.js
@@ -331,8 +331,12 @@ MailParser.prototype._processStateHeader = function(line) {
 
             this._currentNode.meta.generatedFileName = this._generateFileName(this._currentNode.meta.fileName, this._currentNode.meta.contentType);
 
-            this._currentNode.meta.contentId = this._currentNode.meta.contentId ||
-                crypto.createHash("md5").update(new Buffer.from(this._currentNode.meta.generatedFileName, 'utf-8')).digest("hex") + "@mailparser";
+            const originalContentId = this._currentNode.meta.contentId
+            this._currentNode.meta.contentId = originalContentId
+              ? (crypto.createHash('md5').update(originalContentId).digest('hex') +
+                '-' +
+                originalContentId.replace(/[:/\\]+/g, '-'))
+              : crypto.createHash("md5").update(new Buffer.from(this._currentNode.meta.generatedFileName, 'utf-8')).digest("hex") + "@mailparser";
 
             extension = this._currentNode.meta.generatedFileName.split(".").pop().toLowerCase();
 


### PR DESCRIPTION
Fixes https://github.com/maildev/maildev/issues/467
Fixes CVE-2024-27448

This is how we're fixing this:

1. Replace any `/`, back-slash and `:` characters in the `Content-ID` header with `-`.
2. Prepend this with the MD5 of the original `Content-ID` header, so attachments with names `../file.txt` and `..-file.txt` don't overwrite each other.

If this is an approach you guys would be interested in taking forward, I'll look into adding tests to ensure we don't regress on this. Let me know. Thanks for all your work on this project.

The tests are failing because the `cid:...` in HTML messages aren't getting replaced with the URLs to the image attachments themselves. I'm not sure where this replacement is happening, if I can find it, I think I can fix it.