### PR TITLE
Fix auth with no password

### DIFF
--- a/lib/helpers/smtp.js
+++ b/lib/helpers/smtp.js
@@ -6,12 +6,15 @@ const smtpHelpers = module.exports = {}
  * Authorize callback for smtp server
  */
 smtpHelpers.createOnAuthCallback = function (username, password) {
-  return function onAuth (auth, session, callback) {
-    if (auth.username && auth.password) {
-      if (auth.username !== username || auth.password !== password) {
-        return callback(new Error('Invalid username or password'))
-      }
+  return function onAuth(auth, session, callback) {
+    if (!auth.username || !auth.password) {
+      return callback(new Error('Username and password must be provided'));
     }
-    callback(null, { user: username })
-  }
-}
+
+    if (auth.username !== username || auth.password !== password) {
+      return callback(new Error('Invalid username or password'));
+    }
+
+    callback(null, { user: username });
+  };
+};

--- a/lib/helpers/smtp.js
+++ b/lib/helpers/smtp.js
@@ -6,15 +6,12 @@ const smtpHelpers = module.exports = {}
  * Authorize callback for smtp server
  */
 smtpHelpers.createOnAuthCallback = function (username, password) {
-  return function onAuth(auth, session, callback) {
-    if (!auth.username || !auth.password) {
-      return callback(new Error('Username and password must be provided'));
+  return function onAuth (auth, session, callback) {
+    if (auth.username && auth.password) {
+      if (auth.username !== username || auth.password !== password) {
+        return callback(new Error('Invalid username or password'))
+      }
     }
-
-    if (auth.username !== username || auth.password !== password) {
-      return callback(new Error('Invalid username or password'));
-    }
-
-    callback(null, { user: username });
-  };
-};
+    callback(null, { user: username })
+  }
+}


### PR DESCRIPTION
There is an issue for this problem https://github.com/maildev/maildev/issues/436

The problem is that when logging in to an smtp server with username and password configured, you can log in by passing an arbitrary username and an empty password. This is due to an error in the authorization logic implemented in the file smtp.js.

The playback path:

```docker run -p 1080:1080 -p 1025:1025 --name maildev maildev/maildev --incoming-user test --incoming-pass password```

```telnet localhost 1025

EHLO localhost

AUTH LOGIN
334 VXNlcm5hbWU6
admin
334 UGFzc3dvcmQ6

235 Authentication successful
```

This PR fixes this bug