### PR TITLE
Fix Docker healthcheck host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ ENV MAILDEV_WEB_PORT 1080
 ENV MAILDEV_SMTP_PORT 1025
 ENTRYPOINT ["bin/maildev"]
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -O - http://localhost:${MAILDEV_WEB_PORT}${MAILDEV_BASE_PATHNAME}/healthz || exit 1
+  CMD wget -O - http://127.0.0.1:${MAILDEV_WEB_PORT}${MAILDEV_BASE_PATHNAME}/healthz || exit 1


### PR DESCRIPTION
- Docker healthcheck command was using "localhost" but that resolves to ::1 (IPv6) so healthchecks failed.
- Changed the healthcheck to use "127.0.0.1" and healthchecks work as intended.