### PR TITLE
Pagination support for getting all emails

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -71,6 +71,8 @@ Returns:
 
 **GET    /email** - Get all emails
 
+**GET    /email/skip/:number** - Get all emails excepts {number} of emails according to lifetime
+
 **DELETE /email/all** - Delete all emails
 
 **GET    /email/:id** - Get a given email by id

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -26,6 +26,14 @@ module.exports = function (app, mailserver, basePathname) {
     })
   })
 
+  // Get all emails with skip (number - number of emails will be skipped from beginning)
+  router.get('/email/skip/:number', compression(), function (req, res) {
+    mailserver.getAllEmail(function (err, emailList) {
+      if (err) return res.status(404).json([])
+      res.json(emailList.slice(req.params.number))
+    })
+  })
+
   // Get single email
   router.get('/email/:id', function (req, res) {
     mailserver.getEmail(req.params.id, function (err, email) {


### PR DESCRIPTION
We are using MailDev for automated testing purpose.
We have a lot of emails, and we should take a "special email" via REST API.
Unfortunately, existing methods can return only all emails or already-known email.
The problem can be solved like a "get all emails, validate it, repeat until match or timeout". But it's not an effective way.

I propose the way described below.
- get all emails, validate it, **remember the number of emails**
- get all emails excepts the remembered number of emails (counts from beginning of storage)

The new REST endpoint allows it. It allow to read emails by groups, don't read the same emails many times, save traffic and time.