### PR TITLE
Hash filename to prevent file name injections via Content-ID header.

### DIFF
--- a/lib/helpers/attachments.js
+++ b/lib/helpers/attachments.js
@@ -17,7 +17,7 @@ function generateAttachmentFilename(attachment) {
   const ext = path.extname(attachment.generatedFileName)
   // Generate new filename hash
   const name = crypto.createHash('md5').update(attachment.contentId).digest('hex')
-  console.log('Filename:', path.format({ name, ext }))
+  // console.log('Generated filename:', attachment, path.format({ name, ext }))
   return path.format({ name, ext })
 }
 

--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const crypto = require('crypto');
+
+// Return the absolute file path on disk for a given attachment
+function getAttachmentFilePath(mailDir, emailId, attachment) {
+  if (!attachment.transformed) {
+    throw new Error('Attachment must be transformed prior to reading file path')
+  }
+  // transformAttachment modifies the generatedFileName to address CVE-2024-27448
+  return path.join(mailDir, emailId, attachment.generatedFileName)
+}
+
+// Gets the generated filename from a given attachment
+// Fixes: CVE-2024-27448
+function generateAttachmentFilename(attachment) {
+  // Get original extension
+  const ext = path.extname(attachment.generatedFileName)
+  // Generate new filename hash
+  const name = crypto.createHash('md5').update(attachment.contentId).digest('hex')
+  console.log('Filename:', path.format({ name, ext }))
+  return path.format({ name, ext })
+}
+
+function transformAttachment(attachment) {
+  // Add "transformed" boolean flag to later verify that the filename has been transformed
+  return {
+    ...attachment,
+    transformed: true,
+    generatedFileName: generateAttachmentFilename(attachment),
+  }
+}
+
+module.exports.getAttachmentFilePath = getAttachmentFilePath
+module.exports.transformAttachment = transformAttachment;
+

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -17,6 +17,7 @@ const { calculateBcc } = require('./helpers/bcc')
 const outgoing = require('./outgoing')
 const createDOMPurify = require('dompurify')
 const { JSDOM } = require('jsdom')
+const { getAttachmentFilePath, transformAttachment } = require('./helpers/files')
 
 const store = []
 const eventEmitter = new events.EventEmitter()
@@ -51,7 +52,7 @@ function saveEmailToStore (id, isRead = false, envelope, parsedEmail) {
     parsedEmail.attachments && parsedEmail.attachments.length
       ? parsedEmail.attachments.map((attachment) => {
         const { stream, ...remaining } = attachment
-        return remaining
+        return transformAttachment(remaining)
       })
       : null
 
@@ -88,14 +89,13 @@ function saveEmailToStore (id, isRead = false, envelope, parsedEmail) {
 }
 
 // Save an attachment
-function saveAttachment (id, attachment) {
+function saveAttachment (id, rawAttachment) {
   if (!fs.existsSync(path.join(mailServer.mailDir, id))) {
     fs.mkdirSync(path.join(mailServer.mailDir, id))
   }
-  const output = fs.createWriteStream(
-    path.join(mailServer.mailDir, id, attachment.contentId)
-  )
-  attachment.stream.pipe(output)
+  const attachment = transformAttachment(rawAttachment)
+  const output = fs.createWriteStream(getAttachmentFilePath(mailServer.mailDir, id, attachment))
+  rawAttachment.stream.pipe(output)
 }
 
 /**
@@ -500,7 +500,7 @@ mailServer.getEmailAttachment = function (id, filename, done) {
     done(
       null,
       match.contentType,
-      fs.createReadStream(path.join(mailServer.mailDir, id, match.contentId))
+      fs.createReadStream(getAttachmentFilePath(mailServer.mailDir, id, match))
     )
   })
 }

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -17,7 +17,7 @@ const { calculateBcc } = require('./helpers/bcc')
 const outgoing = require('./outgoing')
 const createDOMPurify = require('dompurify')
 const { JSDOM } = require('jsdom')
-const { getAttachmentFilePath, transformAttachment } = require('./helpers/files')
+const { getAttachmentFilePath, transformAttachment } = require('./helpers/attachments')
 
 const store = []
 const eventEmitter = new events.EventEmitter()

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "start": "node ./bin/maildev",
-    "test": "nyc _mocha --exit --timeout 10000",
+    "test": "nyc _mocha --exit --timeout 5000",
     "--test-old": "standard && ",
     "lint": "standard",
     "lint:fix": "standard --fix",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "dev": "node ./scripts/dev.js && npm run css-watch",
+    "send-test-emails": "node ./scripts/send.js",
     "css": "sass --style=compressed --no-source-map assets/styles/style.scss:app/styles/style.css",
     "css-watch": "sass --watch --style=compressed --no-source-map assets/styles/style.scss:app/styles/style.css",
     "docker-build": "./scripts/dockerBuild.sh",

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -185,6 +185,20 @@ const messages = [
   }
   */
 
+  {
+    from: 'Johnny Utah <johnny.utah@fbi.gov>',
+    to: 'Bodhi <bodhi@gmail.com>',
+    subject: 'CVE-2024-27448',
+    html: 'Here she is:<br><img src="cid:../vuln"/>',
+    attachments: [
+      {
+        filename: 'tyler.jpg',
+        path: path.join(__dirname, '/../test/tyler.jpg'),
+        cid: '../vuln'
+      }
+    ]
+  },
+
 ]
 
 function sendEmails (logErrors) {

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -189,7 +189,7 @@ const messages = [
     from: 'Johnny Utah <johnny.utah@fbi.gov>',
     to: 'Bodhi <bodhi@gmail.com>',
     subject: 'CVE-2024-27448',
-    html: 'Here she is:<br><img src="cid:../vuln"/>',
+    html: 'Content-ID should not allow file injection: <img src="cid:../vuln"/>',
     attachments: [
       {
         filename: 'tyler.jpg',

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -8,6 +8,7 @@ const assert = require('assert')
 const fs = require('fs')
 const http = require('http')
 const path = require('path')
+const crypto = require('crypto')
 const nodemailer = require('nodemailer')
 
 const MailDev = require('../index.js')
@@ -150,54 +151,71 @@ describe('email', () => {
   })
 
   it('should handle embedded images with cid', async () => {
+    const prefix = 'test-cid-replacement';
+    const cid = 'image';
     const emailsForTest = [
       {
         from: 'johnny.utah@fbi.gov',
         to: 'bodhi@gmail.com',
-        subject: 'Test cid replacement #1',
-        html: '<img src="cid:image"/>',
+        subject: `${prefix}-1`,
+        html: `<img src="cid:${cid}"/>`,
         attachments: [
           {
             filename: 'tyler.jpg',
             path: path.join(__dirname, 'tyler.jpg'),
-            cid: 'image'
+            cid,
           }
         ]
       },
       {
         from: 'johnny.utah@fbi.gov',
         to: 'bodhi@gmail.com',
-        subject: 'Test cid replacement #2',
-        html: '<img src="cid:image"/>',
+        subject: `${prefix}-2`,
+        html: `<img src="cid:${cid}"/>`,
         attachments: [
           {
             filename: 'wave.jpg',
             path: path.join(__dirname, 'wave.jpg'),
-            cid: 'image'
+            cid,
           }
         ]
       }
     ]
-
     let receivedEmails = 0;
 
     return new Promise((resolve, reject) => {
       maildev.on('new', (email) => {
+        // Filter out other events for other tests
+        if (!email.subject.startsWith(prefix)) {
+          return ;
+        }
         // Simple replacement to root url
         maildev.getEmailHTML(email.id, (_, html) => {
-          const attachmentFilename = (email.subject.endsWith('#1')) ? 'tyler.jpg' : 'wave.jpg'
+          const attachmentFilename = (email.subject.endsWith('1')) ? 'tyler.jpg' : 'wave.jpg'
+          // The filename is hashed based on content id
+          const hashedFilename = function(fileName){
+            return path.format({
+              name: crypto.createHash('md5').update(cid).digest('hex'),
+              ext: path.extname(fileName) })
+          }(attachmentFilename);
           const contentWithoutNewLine = html.replace(/\n/g, '')
-          assert.strictEqual(contentWithoutNewLine, '<html><head></head><body><img src="/email/' + email.id + '/attachment/' + attachmentFilename + '"></body></html>')
-          const host = `${defaultMailDevOpts.ip}:${web}`
-          const attachmentLink = `${host}/email/${email.id}/attachment/${attachmentFilename}`
+          const httpFilePathName = `/email/${email.id}/attachment/${hashedFilename}`
+          assert.strictEqual(contentWithoutNewLine, '<html><head></head><body><img src="'+ httpFilePathName + '"></body></html>')
 
-          // Pass baseUrl
+          // Test host file prefixing:
+          const host = `${defaultMailDevOpts.ip}:${web}`
+          const attachmentUrl = `${host}${httpFilePathName}`
+
+          // Pass baseUrl (host)
           maildev.getEmailHTML(email.id, host, (_, html) => {
             const contentWithoutNewLine = html.replace(/\n/g, '')
-            assert.strictEqual(contentWithoutNewLine, `<html><head></head><body><img src="//${attachmentLink}"></body></html>`)
+            try {
+            assert.strictEqual(contentWithoutNewLine, `<html><head></head><body><img src="//${attachmentUrl}"></body></html>`,
+              'attachment url should be prefixed with host ip and port and protocol-agnostic //'
+            )} catch(err) { reject(err)}
 
             // Check contents of attached/embedded files
-            http.get(`http://${attachmentLink}`, (res) => {
+            http.get(`http://${attachmentUrl}`, (res) => {
               if (res.statusCode !== 200) {
                 return reject(new Error('Failed to get attachment: ' + res.statusCode))
               }
@@ -223,6 +241,58 @@ describe('email', () => {
       emailsForTest.forEach(async (email) => {
         await transporter.sendMail(email)
       })
+    })
+  })
+
+  it('should not allow attachment cid with malicious path (CVE-2024-27448)', async () => {
+    const cid = '../vuln'
+    const filename = 'tyler.jpg'
+    const subject = 'test-CVE-2024-27448'
+    const testEmail = {
+      from: 'johnny.utah@fbi.gov',
+      to: 'bodhi@gmail.com',
+      subject,
+      html: `<img src="cid:${cid}"/>`,
+      attachments: [
+        {
+          filename,
+          path: path.join(__dirname, filename),
+          cid,
+        }
+      ]
+    }
+
+    const hashedFilename = path.format({
+      name: crypto.createHash('md5').update(cid).digest('hex'),
+      ext: path.extname(filename)
+    })
+
+    return new Promise((resolve, reject) => {
+      maildev.on('new', (email) => {
+        // Filter out other events for other tests
+        if (email.subject !== subject) {
+          return;
+        }
+        // Simple replacement to root url
+        maildev.getEmailHTML(email.id, (_, html) => {
+          const contentWithoutNewLine = html.replace(/\n/g, '')
+          const httpFilePathName = `/email/${email.id}/attachment/${hashedFilename}`
+          try {
+            assert.strictEqual(contentWithoutNewLine, '<html><head></head><body><img src="'+ httpFilePathName + '"></body></html>',
+              'it should contain the properly hashed cid filename'
+            )
+            // Also tests getAttachmentFilePath in this integration test
+            const filePath = path.join(maildev.mailDir, email.id, hashedFilename)
+            const isFileAtCorrectPath = fs.existsSync(filePath)
+            assert.ok(isFileAtCorrectPath, 'attachment file was created at the correct location within the temp directory')
+            resolve();
+          } catch (err) {
+            return reject(err);
+          }
+        })
+      })
+
+      transporter.sendMail(testEmail)
     })
   })
 })


### PR DESCRIPTION
## Description
Builds on the idea in #487 to prevent file name injections with the `Content-ID` header. 

Fixes CVE-2024-27448. 
Fixes #487.

## Explanation

Previously, the `Content-ID` header was directly used to write temporary attachment files to disk. This was problematic as the code was writing the file to disk with a simple `path.join` and the `Content-ID` could contain any characters including a relative path prefix. This allowed the attachment to be saved in any directory on disk. 

The fix for this is to always transform the attachment object as it is parsed from Mailparser and generate our own filename. The generated filename is a hash of the content id with the original file extension. This hashing prevents any relative pathnames from being used.

This also centralizes some logic in an attempt to prevent future regressions and issues.