### PR TITLE
Deny rcpts feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = function (config) {
     config.hideExtensions,
     config.incomingSecure,
     config.incomingCert,
-    config.incomingKey
+    config.incomingKey,
+    config.denyRcptsRegexp
   )
 
   if (

--- a/lib/mailserver.js
+++ b/lib/mailserver.js
@@ -172,10 +172,19 @@ mailServer.create = function (
   hideExtensions,
   isSecure,
   certFilePath,
-  keyFilePath
+  keyFilePath,
+  denyRcpts
 ) {
   mailServer.mailDir = mailDir || defaultMailDir
   createMailDir()
+
+  const denyRcptsRegexp = denyRcpts ? new RegExp(denyRcpts) : undefined;
+  function onRcptTo(address, session, callback) {
+    if (denyRcptsRegexp && denyRcptsRegexp.test(address.address)) {
+      return callback(new Error('Recipient denied'))
+    }
+    callback()
+  }
 
   const hideExtensionOptions = getHideExtensionOptions(hideExtensions)
   const smtpServerConfig = Object.assign(
@@ -187,7 +196,8 @@ mailServer.create = function (
       onData: handleDataStream,
       logger: false,
       hideSTARTTLS: true,
-      disabledCommands: user && password ? (isSecure ? [] : ['STARTTLS']) : ['AUTH']
+      disabledCommands: user && password ? (isSecure ? [] : ['STARTTLS']) : ['AUTH'],
+      onRcptTo
     },
     hideExtensionOptions
   )

--- a/lib/options.js
+++ b/lib/options.js
@@ -19,6 +19,7 @@ module.exports.options = [
   ['--incoming-secure', 'MAILDEV_INCOMING_SECURE', 'Use SMTP SSL for incoming emails', false],
   ['--incoming-cert <path>', 'MAILDEV_INCOMING_CERT', 'Cert file location for incoming SSL'],
   ['--incoming-key <path>', 'MAILDEV_INCOMING_KEY', 'Key file location for incoming SSL'],
+  ['--deny-rcpts-regexp <rcpts_regexp>', 'MAILDEV_DENY_RCPTS_REGEXP', 'Regex pattern for recipients to deny'],
   ['--web-ip <ip address>', 'MAILDEV_WEB_IP', 'IP Address to bind HTTP service to, defaults to --ip'],
   ['--web-user <user>', 'MAILDEV_WEB_USER', 'HTTP user for GUI'],
   ['--web-pass <password>', 'MAILDEV_WEB_PASS', 'HTTP password for GUI'],

--- a/test/mailserver.test.js
+++ b/test/mailserver.test.js
@@ -27,7 +27,8 @@ describe('mailserver', () => {
       incomingPass: 'surfing',
       silent: true,
       disableWeb: true,
-      smtp: port
+      smtp: port,
+      denyRcptsRegexp: 'fail@example.com'
     })
     maildev.listen(done)
   })
@@ -60,6 +61,36 @@ describe('mailserver', () => {
             await waitMailDevShutdown(maildevConflict)
             resolve()
           }
+        })
+      })
+    })
+  })
+
+  describe('smtp deny rcpts feature', () => {
+    it('should deny rcpts', function (done) {
+      const connection = new SMTPConnection({
+        port: maildev.port,
+        host: maildev.host,
+        tls: {
+          rejectUnauthorized: false
+        }
+      })
+
+      connection.connect(function (err) {
+        if (err) return done(err)
+
+        const envelope = {
+          from: 'willfail@example.com',
+          to: 'fail@example.com'
+        }
+
+        connection.send(envelope, 'Will be rejected', function (err) {
+          // This should return an error since the recipient is denied
+          assert.notStrictEqual(typeof err, 'undefined')
+          assert.strictEqual(err.code, 'EENVELOPE')
+
+          connection.close()
+          maildev.close(done)
         })
       })
     })


### PR DESCRIPTION
I'm using maildev to test an email app of my own, using its API to pull received messages, and I'm running into the need to make some recipients fail.

I'm familiar with Nodemailer and its ecosystem so it was pretty straightforward using `onRcptTo` for this purpose.

Let me know if I should add more docs or change anything else.