### PR TITLE
Use correct licensing text of MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2023 Dan Farrelly
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -6,6 +8,9 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
GitHub is currently not detecting the license as MIT:

<img width="126" height="38" alt="grafik" src="https://github.com/user-attachments/assets/99134fed-f825-45ee-bd09-aaf6a8ffc872" />

This is the case because the wording is incorrect.

This PR updates the license wording to be the same as is in the MIT license.
