### PR TITLE
Fix attachment download links

### DIFF
--- a/packages/ui/src/components/email-viewer/EmailHeader.tsx
+++ b/packages/ui/src/components/email-viewer/EmailHeader.tsx
@@ -324,7 +324,7 @@ export function EmailHeader({ email }: EmailHeaderProps) {
           {email.attachments.map((attachment, index) => (
             <Tooltip key={index} content={`Download ${attachment.filename ?? 'attachment'}`}>
               <a
-                href={api.emails.attachmentUrl(email.id, attachment.filename ?? `attachment-${index}`)}
+                href={api.emails.attachmentUrl(email.id, attachment.generatedFileName)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={cn(


### PR DESCRIPTION
## Summary

Fixes attachment downloads from the web UI by using the generated attachment filename in the download URL.

## Details

Attachment files are stored and resolved by their generated filename, but the UI was building download URLs from the original display filename. This caused attachment download requests to return 404 when those values differed.

The UI still displays the original attachment filename; only the URL identifier changes.

Fixes #513.

## Validation

- Built @maildev/core first so workspace types are available
- Ran `pnpm --filter @maildev/ui typecheck`
- Ran `pnpm --filter @maildev/ui lint`