### PR TITLE
Add bulk email delete endpoint

### DIFF
--- a/.changeset/add-bulk-delete-emails.md
+++ b/.changeset/add-bulk-delete-emails.md
@@ -1,0 +1,5 @@
+---
+'@maildev/api': patch
+---
+
+Add a bulk delete endpoint for deleting multiple emails by ID.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -70,6 +70,8 @@ All paths are relative to the `/api` prefix.
 
 **DELETE /api/email/:id** - Delete a given email by id
 
+**POST   /api/email/delete** - Delete multiple emails by id
+
 **DELETE /api/email/all** - Delete all emails
 
 **PATCH  /api/email/read-all** - Mark all emails as read (returns the count)
@@ -93,6 +95,26 @@ directory
 **GET    /api/config** - Get the application configuration
 
 **GET    /api/healthz** - Health check
+
+## Bulk Delete
+
+The **POST /api/email/delete** endpoint deletes a specific set of emails in one
+request. The request body must include an `ids` array.
+
+```json
+{
+  "ids": ["XwgKAxto", "29wQJq2q"]
+}
+```
+
+It returns the IDs that were deleted and any IDs that were not found:
+
+```json
+{
+  "deleted": ["XwgKAxto"],
+  "notFound": ["29wQJq2q"]
+}
+```
 
 ## Real-time updates
 

--- a/packages/api/src/__tests__/server.test.ts
+++ b/packages/api/src/__tests__/server.test.ts
@@ -228,6 +228,116 @@ describe('APIServer', () => {
       expect(deleted).toBeUndefined()
     })
 
+    it('should delete multiple emails on POST /email/delete', async () => {
+      const emails: Email[] = [
+        {
+          id: 'bulk-1',
+          time: new Date(),
+          read: false,
+          subject: 'Bulk Email 1',
+          source: '/path/1.eml',
+          size: 100,
+          sizeHuman: '100 B',
+          from: [{ address: 'a@test.com' }],
+          to: [{ address: 'b@test.com' }],
+          headers: {},
+          attachments: [],
+          envelope: { from: { address: 'a@test.com' }, to: [{ address: 'b@test.com' }] },
+          calculatedBcc: [],
+        },
+        {
+          id: 'bulk-2',
+          time: new Date(),
+          read: false,
+          subject: 'Bulk Email 2',
+          source: '/path/2.eml',
+          size: 200,
+          sizeHuman: '200 B',
+          from: [{ address: 'c@test.com' }],
+          to: [{ address: 'd@test.com' }],
+          headers: {},
+          attachments: [],
+          envelope: { from: { address: 'c@test.com' }, to: [{ address: 'd@test.com' }] },
+          calculatedBcc: [],
+        },
+        {
+          id: 'keep-me',
+          time: new Date(),
+          read: false,
+          subject: 'Keep Email',
+          source: '/path/3.eml',
+          size: 300,
+          sizeHuman: '300 B',
+          from: [{ address: 'e@test.com' }],
+          to: [{ address: 'f@test.com' }],
+          headers: {},
+          attachments: [],
+          envelope: { from: { address: 'e@test.com' }, to: [{ address: 'f@test.com' }] },
+          calculatedBcc: [],
+        },
+      ]
+
+      for (const email of emails) {
+        await storage.save(email)
+      }
+
+      server = createAPIServer({ storage, port: 0 })
+      await server.start()
+
+      const response = await server.server.inject({
+        method: 'POST',
+        url: '/api/email/delete',
+        payload: {
+          ids: ['bulk-1', 'bulk-2', 'bulk-1', 'missing'],
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        deleted: ['bulk-1', 'bulk-2'],
+        notFound: ['missing'],
+      })
+
+      expect(await storage.getById('bulk-1')).toBeUndefined()
+      expect(await storage.getById('bulk-2')).toBeUndefined()
+      expect(await storage.getById('keep-me')).toBeDefined()
+    })
+
+    it('should reject invalid bulk delete payloads', async () => {
+      server = createAPIServer({ storage, port: 0 })
+      await server.start()
+
+      const missingBodyResponse = await server.server.inject({
+        method: 'POST',
+        url: '/api/email/delete',
+      })
+
+      expect(missingBodyResponse.statusCode).toBe(400)
+      expect(missingBodyResponse.json()).toEqual({
+        error: 'Request body must include an ids array of email IDs',
+      })
+
+      const invalidPayloads: Array<Record<string, unknown>> = [
+        {},
+        { ids: 'not-an-array' },
+        { ids: ['valid-id', ''] },
+        { ids: ['valid-id', 123] },
+      ]
+
+      for (const payload of invalidPayloads) {
+        const response = await server.server.inject({
+          method: 'POST',
+          url: '/api/email/delete',
+          payload,
+        })
+
+        expect(response.statusCode).toBe(400)
+        expect(response.json()).toEqual({
+          error: 'Request body must include an ids array of email IDs',
+        })
+      }
+    })
+
     it('should delete all emails on DELETE /email/all', async () => {
       const emails: Email[] = [
         {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -15,7 +15,12 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { registerMCPHandlers, type EmailDataSource } from '@maildev/mcp'
 import type { Storage, Email } from '@maildev/core'
 import type { SMTPServer } from '@maildev/smtp'
-import type { APIServerOptions, AuthConfig, ConfigResponse } from './types.js'
+import type {
+  APIServerOptions,
+  AuthConfig,
+  BulkDeleteEmailsRequest,
+  ConfigResponse,
+} from './types.js'
 import { VERSION } from './index.js'
 
 const DEFAULT_PORT = 1080
@@ -220,21 +225,51 @@ export class APIServer extends EventEmitter {
     )
 
     // Delete single email
-    this.app.delete<{ Params: { id: string } }>(
-      `${apiPath}/email/:id`,
+    this.app.delete<{ Params: { id: string } }>(`${apiPath}/email/:id`, async (request, reply) => {
+      const { id } = request.params
+
+      try {
+        const deleted = await this.deleteEmail(id)
+        if (!deleted) {
+          return reply.status(404).send({ error: 'Email was not found' })
+        }
+        return true
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        return reply.status(500).send({ error: message })
+      }
+    })
+
+    // Delete multiple emails
+    this.app.post<{ Body: BulkDeleteEmailsRequest }>(
+      `${apiPath}/email/delete`,
       async (request, reply) => {
-        const { id } = request.params
+        const ids = request.body?.ids
+
+        if (
+          !Array.isArray(ids) ||
+          ids.some((id) => typeof id !== 'string' || id.trim().length === 0)
+        ) {
+          return reply
+            .status(400)
+            .send({ error: 'Request body must include an ids array of email IDs' })
+        }
+
+        const uniqueIds = Array.from(new Set(ids))
+        const deleted: string[] = []
+        const notFound: string[] = []
 
         try {
-          if (this.smtp) {
-            await this.smtp.deleteEmail(id)
-          } else {
-            const deleted = await this.storage.delete(id)
-            if (!deleted) {
-              return reply.status(404).send({ error: 'Email was not found' })
+          for (const id of uniqueIds) {
+            const wasDeleted = await this.deleteEmail(id)
+            if (wasDeleted) {
+              deleted.push(id)
+            } else {
+              notFound.push(id)
             }
           }
-          return true
+
+          return { deleted, notFound }
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error'
           return reply.status(500).send({ error: message })
@@ -427,6 +462,23 @@ export class APIServer extends EventEmitter {
         return reply.status(500).send({ error: message })
       }
     })
+  }
+
+  /**
+   * Delete one email using SMTP when available so delete events are emitted.
+   */
+  private async deleteEmail(id: string): Promise<boolean> {
+    const email = await this.storage.getById(id)
+    if (!email) {
+      return false
+    }
+
+    if (this.smtp) {
+      await this.smtp.deleteEmail(id)
+      return true
+    }
+
+    return this.storage.delete(id)
   }
 
   /**

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -88,6 +88,21 @@ export interface ConfigResponse {
 }
 
 /**
+ * Request body for deleting multiple emails.
+ */
+export interface BulkDeleteEmailsRequest {
+  ids: string[]
+}
+
+/**
+ * Response for deleting multiple emails.
+ */
+export interface BulkDeleteEmailsResponse {
+  deleted: string[]
+  notFound: string[]
+}
+
+/**
  * API Server events
  */
 export interface APIServerEvents {


### PR DESCRIPTION
## Summary
- Add POST /api/email/delete for deleting multiple emails by ID in one request
- Return deleted and notFound ID lists so clients can handle partial matches
- Reuse the existing SMTP delete path when available so delete events still emit
- Document the endpoint and add a patch changeset for @maildev/api

Fixes #520

## Verification
- corepack pnpm --filter @maildev/api test
- corepack pnpm --filter @maildev/api typecheck
- corepack pnpm --filter @maildev/api lint
- corepack pnpm --filter @maildev/api build
- End-to-end checked with the local dev API/SMTP stack using synthetic emails