### PR TITLE
Fix web UI serving under a non-root base path

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/maildev-icon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./maildev-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="MailDev - SMTP Server + Web Interface for viewing and testing emails during development" />
     <title>MailDev</title>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,6 +60,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "fastify": "^5.0.0",
     "jsdom": "^26.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",

--- a/packages/ui/server/index.test.ts
+++ b/packages/ui/server/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { injectBaseTag } from './index'
+
+const HTML = '<!doctype html>\n<html>\n  <head>\n    <title>MailDev</title>\n  </head>\n  <body></body>\n</html>'
+
+describe('injectBaseTag', () => {
+  it("injects a root <base> when no base path is configured", () => {
+    expect(injectBaseTag(HTML, '')).toContain('<base href="/" />')
+  })
+
+  it('injects the configured base path with a trailing slash', () => {
+    expect(injectBaseTag(HTML, '/mail')).toContain('<base href="/mail/" />')
+  })
+
+  it('does not double the trailing slash', () => {
+    expect(injectBaseTag(HTML, '/mail/')).toContain('<base href="/mail/" />')
+    expect(injectBaseTag(HTML, '/mail/')).not.toContain('//"')
+  })
+
+  it('inserts the tag inside <head>, keeping existing content', () => {
+    const out = injectBaseTag(HTML, '/mail')
+    expect(out.indexOf('<base')).toBeGreaterThan(out.indexOf('<head>'))
+    expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<title>'))
+  })
+})

--- a/packages/ui/server/index.ts
+++ b/packages/ui/server/index.ts
@@ -1,32 +1,66 @@
+import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyReply } from 'fastify'
 import fastifyStatic from '@fastify/static'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface RegisterUIOptions {
   basePath?: string
+  /** Directory containing the built UI. Defaults to the packaged `dist/`. */
+  distPath?: string
+}
+
+/** Strip trailing slashes: '/mail/' -> '/mail', '/' -> ''. */
+function stripTrailingSlash(path: string): string {
+  return path.replace(/\/+$/, '')
+}
+
+/**
+ * Inject a `<base href="{basePath}/">` tag into index.html.
+ *
+ * The Vite build emits relative asset URLs (`base: './'`), and the client
+ * derives its REST/Socket.io prefixes from `document.baseURI`. Both rely on
+ * this tag so MailDev can be served at the root or under a reverse-proxy
+ * sub-path without a rebuild.
+ */
+export function injectBaseTag(html: string, basePath: string): string {
+  const href = `${stripTrailingSlash(basePath)}/`
+  return html.replace(
+    /<head(\s[^>]*)?>/i,
+    (match) => `${match}\n    <base href="${href}" />`
+  )
 }
 
 export async function registerUI(
   fastify: FastifyInstance,
   options: RegisterUIOptions = {}
 ): Promise<void> {
-  const basePath = options.basePath ?? ''
-  const distPath = resolve(__dirname, '..', 'dist')
+  const basePath = stripTrailingSlash(options.basePath ?? '')
+  const distPath = options.distPath ?? resolve(__dirname, '..', 'dist')
 
+  // Pre-render index.html with the <base> tag for the configured base path.
+  const rawIndex = await readFile(resolve(distPath, 'index.html'), 'utf8')
+  const indexHtml = injectBaseTag(rawIndex, basePath)
+  const sendIndex = (reply: FastifyReply) =>
+    reply.type('text/html').send(indexHtml)
+
+  // Serve hashed assets under the base path prefix. `index: false` leaves
+  // index.html to the handlers below so the injected <base> tag is always used.
   await fastify.register(fastifyStatic, {
     root: distPath,
     prefix: basePath || '/',
     wildcard: false,
+    index: false,
   })
 
-  // SPA fallback - serves index.html for unmatched GET requests
+  // SPA fallback - serves index.html for unmatched GET requests (incl. the
+  // base path root itself, which `index: false` no longer auto-serves).
   fastify.setNotFoundHandler(async (request, reply) => {
     const acceptHeader = request.headers.accept || ''
     if (request.method === 'GET' && acceptHeader.includes('text/html')) {
-      return reply.sendFile('index.html')
+      return sendIndex(reply)
     }
     return reply.status(404).send({ error: 'Not found' })
   })

--- a/packages/ui/server/registerUI.test.ts
+++ b/packages/ui/server/registerUI.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { registerUI } from './index'
+
+const INDEX_HTML =
+  '<!doctype html>\n<html>\n  <head>\n    <link rel="icon" href="./maildev-icon.svg" />\n' +
+  '    <title>MailDev</title>\n  </head>\n  <body>\n    <script type="module" src="./assets/app.js"></script>\n  </body>\n</html>'
+
+let distPath: string
+
+beforeAll(async () => {
+  // Build a fake UI dist so the test doesn't depend on a real Vite build.
+  distPath = await mkdtemp(join(tmpdir(), 'maildev-ui-'))
+  await mkdir(join(distPath, 'assets'), { recursive: true })
+  await writeFile(join(distPath, 'index.html'), INDEX_HTML)
+  await writeFile(join(distPath, 'assets', 'app.js'), 'console.log("app")')
+  await writeFile(join(distPath, 'maildev-icon.svg'), '<svg/>')
+})
+
+afterAll(async () => {
+  await rm(distPath, { recursive: true, force: true })
+})
+
+async function buildServer(basePath: string): Promise<FastifyInstance> {
+  const app = Fastify()
+  await registerUI(app, { basePath, distPath })
+  await app.ready()
+  return app
+}
+
+describe('registerUI', () => {
+  describe.each([
+    { basePath: '', root: '/', label: 'root' },
+    { basePath: '/mail', root: '/mail/', label: 'sub-path' },
+  ])('served under $label (basePath=$basePath)', ({ basePath, root }) => {
+    it('serves index.html with a <base> tag for the base path', async () => {
+      const app = await buildServer(basePath)
+      const res = await app.inject({
+        method: 'GET',
+        url: root,
+        headers: { accept: 'text/html' },
+      })
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['content-type']).toContain('text/html')
+      expect(res.body).toContain(`<base href="${basePath}/" />`)
+      await app.close()
+    })
+
+    it('serves hashed assets under the base path prefix', async () => {
+      const app = await buildServer(basePath)
+      const res = await app.inject({ method: 'GET', url: `${basePath}/assets/app.js` })
+      expect(res.statusCode).toBe(200)
+      expect(res.body).toContain('console.log')
+      await app.close()
+    })
+
+    it('falls back to index.html for unknown HTML routes (SPA)', async () => {
+      const app = await buildServer(basePath)
+      const res = await app.inject({
+        method: 'GET',
+        url: `${basePath}/does-not-exist`,
+        headers: { accept: 'text/html' },
+      })
+      expect(res.statusCode).toBe(200)
+      expect(res.body).toContain(`<base href="${basePath}/" />`)
+      await app.close()
+    })
+
+    it('returns JSON 404 for unknown non-HTML routes', async () => {
+      const app = await buildServer(basePath)
+      const res = await app.inject({
+        method: 'GET',
+        url: `${basePath}/api/missing`,
+        headers: { accept: 'application/json' },
+      })
+      expect(res.statusCode).toBe(404)
+      expect(res.json()).toEqual({ error: 'Not found' })
+      await app.close()
+    })
+  })
+
+  it("normalizes a base path with a trailing slash", async () => {
+    const app = await buildServer('/mail/')
+    const res = await app.inject({ method: 'GET', url: '/mail/', headers: { accept: 'text/html' } })
+    expect(res.body).toContain('<base href="/mail/" />')
+    expect(res.body).not.toContain('<base href="/mail//')
+    await app.close()
+  })
+})

--- a/packages/ui/src/hooks/useSocket.ts
+++ b/packages/ui/src/hooks/useSocket.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { io, Socket } from 'socket.io-client'
 import type { Email } from '@maildev/core'
 import { useUIStore } from '../stores/ui'
+import { getBasePath } from '../lib/basePath'
 
 // Notification debounce - max 1 notification per 2 seconds
 let lastNotificationTime = 0
@@ -69,7 +70,7 @@ export function useSocket() {
   useEffect(() => {
     // Connect to Socket.io
     const socket = io({
-      path: '/socket.io',
+      path: `${getBasePath()}/socket.io`,
       transports: ['websocket', 'polling'],
     })
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type { Email } from '@maildev/core'
+import { getBasePath } from './basePath'
 
-const API_BASE = '/api'
+const API_BASE = `${getBasePath()}/api`
 
 export interface ConfigResponse {
   version: string

--- a/packages/ui/src/lib/basePath.test.ts
+++ b/packages/ui/src/lib/basePath.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getBasePath } from './basePath'
+
+function setBaseHref(href: string | null): void {
+  document.head.querySelector('base')?.remove()
+  if (href !== null) {
+    const base = document.createElement('base')
+    base.setAttribute('href', href)
+    document.head.appendChild(base)
+  }
+}
+
+describe('getBasePath', () => {
+  afterEach(() => setBaseHref(null))
+
+  it("returns '' when served at the root (base href '/')", () => {
+    setBaseHref('/')
+    expect(getBasePath()).toBe('')
+  })
+
+  it("returns '' when no <base> tag is present (dev server)", () => {
+    setBaseHref(null)
+    expect(getBasePath()).toBe('')
+  })
+
+  it('returns the prefix without a trailing slash for a sub-path', () => {
+    setBaseHref('/mail/')
+    expect(getBasePath()).toBe('/mail')
+  })
+
+  it('handles a nested base path', () => {
+    setBaseHref('/apps/mail/')
+    expect(getBasePath()).toBe('/apps/mail')
+  })
+})

--- a/packages/ui/src/lib/basePath.ts
+++ b/packages/ui/src/lib/basePath.ts
@@ -1,0 +1,26 @@
+/**
+ * Base-path resolution for the MailDev UI client.
+ *
+ * MailDev can be mounted under a non-root base path (e.g. behind a reverse
+ * proxy at `/mail`). The static server injects a `<base href="{basePath}/">`
+ * tag into index.html, so `document.baseURI` reflects the configured base
+ * path. We derive the REST API and Socket.io prefixes from it here.
+ *
+ * In the Vite dev server no `<base>` tag is present and MailDev is served at
+ * the root, so this resolves to '' — matching the dev proxy for `/api` and
+ * `/socket.io`.
+ */
+
+/** Strip trailing slashes: '/mail/' -> '/mail', '/' -> ''. */
+function stripTrailingSlash(path: string): string {
+  return path.replace(/\/+$/, '')
+}
+
+/**
+ * The base path the UI is served under, as a prefix without a trailing slash
+ * ('' when served at the root).
+ */
+export function getBasePath(): string {
+  if (typeof document === 'undefined') return ''
+  return stripTrailingSlash(new URL(document.baseURI).pathname)
+}

--- a/packages/ui/tsconfig.server.json
+++ b/packages/ui/tsconfig.server.json
@@ -9,5 +9,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["server/**/*"]
+  "include": ["server/**/*"],
+  "exclude": ["server/**/*.test.ts"]
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -4,6 +4,10 @@ import tailwindcss from '@tailwindcss/vite'
 import { resolve } from 'path'
 
 export default defineConfig({
+  // Relative base so the built asset URLs resolve against the injected
+  // <base href> tag, letting MailDev be served under any base path
+  // (root or a reverse-proxy sub-path) without a rebuild.
+  base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.11
-        version: 2.29.8(@types/node@22.19.7)
+        version: 2.29.8(@types/node@25.0.8)
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.39.2
@@ -238,9 +238,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      fastify:
-        specifier: ^5.10.0
-        version: 5.10.0
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -278,6 +275,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@7.3.6(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.2)(tsx@4.21.0))
+      fastify:
+        specifier: ^5.10.0
+        version: 5.10.0
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -3401,7 +3401,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@22.19.7)':
+  '@changesets/cli@2.29.8(@types/node@25.0.8)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -3417,7 +3417,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.7)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.0.8)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -3722,12 +3722,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.7)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.0.8)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.7
+      '@types/node': 25.0.8
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
## Summary

Makes the web UI actually work under a non-root base path. The `--base-pathname` option (env `MAILDEV_BASE_PATHNAME`) is already wired through the orchestrator to both the API server and `registerUI`, but the built v3 UI ignored it — so under any non-root base path the app failed to load.

## Problem

- The built `index.html` referenced assets with absolute paths (`/assets/...`), so under a base path prefix the browser requested them from the root and got 404s — the JS/CSS never loaded.
- The client hardcoded `/api` and `/socket.io`, so REST and WebSocket requests missed the prefixed routes even if the app had loaded.

## Changes

- **vite**: emit relative asset URLs (`base: './'`).
- **UI server**: inject `<base href="{basePath}/">` into `index.html`, and set `index: false` so `@fastify/static` no longer auto-serves the untransformed index. Added an exported, testable `injectBaseTag`.
- **client**: derive the base path from `document.baseURI` (`getBasePath`) and prefix the REST API + Socket.io paths with it.
- **registerUI**: accept an optional `distPath` (defaults to the packaged `dist/`), used for hermetic testing.

## Tests

- `getBasePath` — root, dev (no `<base>`), sub-path, nested path.
- `injectBaseTag` — root, prefix, no double-slash, placement.
- `registerUI` HTTP integration (Fastify `inject`), parametrized over root and `/mail`: index served with correct `<base>`, hashed assets serve under the prefix, SPA fallback, JSON 404 for unknown non-HTML routes.

## Validation

- `pnpm --filter @maildev/ui typecheck | lint | test` (17 tests) — all pass
- `pnpm typecheck` (full monorepo) — all pass
- Verified end-to-end over HTTP with `registerUI` mounted at both `/mail` and root.

## Note (out of scope)

`maildev-icon.svg` is referenced by `index.html` but does not exist in the repo (no `public/` dir), so the favicon 404s regardless of base path — a pre-existing issue, worth a separate fix.
