### PR TITLE
feat(ui): add email dashboard routes

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from './stores/ui'
 import { useEmails } from './hooks/useEmails'
 import { useFaviconBadge } from './hooks/useFaviconBadge'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { useEmailRoute } from './hooks/useEmailRoute'
 import type { Email } from '@maildev/core'
 
 const queryClient = new QueryClient({
@@ -32,6 +33,9 @@ function AppContent() {
 
   // Global keyboard shortcuts
   useKeyboardShortcuts()
+
+  // Deep-link the selected email and follow browser back/forward navigation
+  useEmailRoute()
 
   // Apply theme class to document
   useEffect(() => {

--- a/packages/ui/src/hooks/useEmailRoute.test.ts
+++ b/packages/ui/src/hooks/useEmailRoute.test.ts
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '../stores/ui'
+import { useEmailRoute } from './useEmailRoute'
+
+describe('useEmailRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '#/')
+    useUIStore.getState().syncSelectedEmailFromRoute(null)
+  })
+
+  it('updates the route when an email is selected', () => {
+    renderHook(() => useEmailRoute())
+
+    act(() => useUIStore.getState().setSelectedEmail('email-123'))
+
+    expect(window.location.hash).toBe('#/email/email-123')
+  })
+
+  it('updates the selection when the hash route changes', () => {
+    renderHook(() => useEmailRoute())
+
+    act(() => {
+      window.history.pushState(null, '', '#/email/email-456')
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    })
+
+    expect(useUIStore.getState().selectedEmailId).toBe('email-456')
+  })
+})

--- a/packages/ui/src/hooks/useEmailRoute.ts
+++ b/packages/ui/src/hooks/useEmailRoute.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { parseEmailRoute } from '../lib/emailRoute'
+import { useUIStore } from '../stores/ui'
+
+/** Keep browser back/forward navigation in sync with the selected email. */
+export function useEmailRoute(): void {
+  useEffect(() => {
+    const syncSelectionFromRoute = () => {
+      useUIStore.getState().syncSelectedEmailFromRoute(parseEmailRoute(window.location.hash))
+    }
+
+    syncSelectionFromRoute()
+    window.addEventListener('hashchange', syncSelectionFromRoute)
+    return () => window.removeEventListener('hashchange', syncSelectionFromRoute)
+  }, [])
+}

--- a/packages/ui/src/lib/emailRoute.test.ts
+++ b/packages/ui/src/lib/emailRoute.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildEmailRoute, parseEmailRoute } from './emailRoute'
+
+describe('email dashboard routes', () => {
+  it('builds and parses the MailDev email route', () => {
+    const hash = buildEmailRoute('email id/with/slashes')
+
+    expect(hash).toBe('#/email/email%20id%2Fwith%2Fslashes')
+    expect(parseEmailRoute(hash)).toBe('email id/with/slashes')
+  })
+
+  it('uses the dashboard route when no email is selected', () => {
+    expect(buildEmailRoute(null)).toBe('#/')
+    expect(parseEmailRoute('#/')).toBeNull()
+  })
+
+  it('rejects malformed or unrelated routes', () => {
+    expect(parseEmailRoute('#/email/')).toBeNull()
+    expect(parseEmailRoute('#/email/not/one-id')).toBeNull()
+    expect(parseEmailRoute('#/settings')).toBeNull()
+    expect(parseEmailRoute('#/email/%E0%A4%A')).toBeNull()
+  })
+})

--- a/packages/ui/src/lib/emailRoute.ts
+++ b/packages/ui/src/lib/emailRoute.ts
@@ -1,0 +1,34 @@
+const EMAIL_ROUTE_PREFIX = '#/email/'
+
+/** Return the selected email ID encoded in a dashboard hash route. */
+export function parseEmailRoute(hash: string): string | null {
+  if (!hash.startsWith(EMAIL_ROUTE_PREFIX)) {
+    return null
+  }
+
+  const encodedId = hash.slice(EMAIL_ROUTE_PREFIX.length)
+  if (!encodedId || encodedId.includes('/')) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(encodedId)
+  } catch {
+    return null
+  }
+}
+
+/** Build a dashboard hash route compatible with MailDev 2.x email links. */
+export function buildEmailRoute(id: string | null): string {
+  return id ? `${EMAIL_ROUTE_PREFIX}${encodeURIComponent(id)}` : '#/'
+}
+
+/** Update the browser route without adding duplicate history entries. */
+export function updateEmailRoute(id: string | null): void {
+  if (typeof window === 'undefined') return
+
+  const nextHash = buildEmailRoute(id)
+  if (window.location.hash !== nextHash) {
+    window.location.hash = nextHash
+  }
+}

--- a/packages/ui/src/stores/ui.ts
+++ b/packages/ui/src/stores/ui.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { parseEmailRoute, updateEmailRoute } from '../lib/emailRoute'
 
 interface UIState {
   /** Currently selected email ID */
@@ -19,6 +20,7 @@ interface UIState {
 
   // Actions
   setSelectedEmail: (id: string | null) => void
+  syncSelectedEmailFromRoute: (id: string | null) => void
   toggleTheme: () => void
   setTheme: (theme: 'light' | 'dark') => void
   setSearchQuery: (query: string) => void
@@ -32,7 +34,7 @@ interface UIState {
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
-      selectedEmailId: null,
+      selectedEmailId: typeof window === 'undefined' ? null : parseEmailRoute(window.location.hash),
       theme: 'light',
       searchQuery: '',
       sidebarCollapsed: false,
@@ -40,7 +42,12 @@ export const useUIStore = create<UIState>()(
       autoShowNewMail: false,
       commandPaletteOpen: false,
 
-      setSelectedEmail: (id) => set({ selectedEmailId: id }),
+      setSelectedEmail: (id) => {
+        set({ selectedEmailId: id })
+        updateEmailRoute(id)
+      },
+
+      syncSelectedEmailFromRoute: (id) => set({ selectedEmailId: id }),
 
       toggleTheme: () =>
         set((state) => ({


### PR DESCRIPTION
## Summary

- add hash-based dashboard links for selected emails using the MailDev 2.x-compatible `#/email/:id` route
- restore the selected email from a shared URL and keep browser back/forward navigation in sync
- encode email IDs safely and add route/state synchronization tests

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @maildev/ui test`
- each workspace package test command passed individually (`core`, `smtp`, `api`, `ui`, `mcp`, and `cli`)

The concurrent root `pnpm test` orchestration hit Vitest worker RPC timeouts on this constrained runner; the same package suites pass when run separately. CI can exercise the canonical concurrent invocation.

Fixes #533
