### PR TITLE
Restore persisted emails on startup

### DIFF
--- a/.changeset/restore-mail-on-startup.md
+++ b/.changeset/restore-mail-on-startup.md
@@ -1,0 +1,5 @@
+---
+'maildev': patch
+---
+
+Restore persisted emails on startup. When `--mail-directory` (`MAILDEV_MAIL_DIRECTORY`) is set, existing `.eml` files in the directory are now loaded back into the UI when MailDev starts, so mail survives a restart (e.g. across container/pod restarts with a mounted volume).

--- a/packages/cli/src/server/orchestrator.ts
+++ b/packages/cli/src/server/orchestrator.ts
@@ -109,6 +109,15 @@ export class Orchestrator {
     await this.smtp.start()
     this.logger.debug(`SMTP server started on ${this.config.ip}:${this.config.smtp}`)
 
+    // 6b. Restore persisted emails when a mail directory is configured, so mail
+    // survives restarts (e.g. across pod/container restarts with a mounted
+    // volume). Only when explicitly persisting — the tmpdir fallback is not
+    // restored to avoid resurrecting mail from unrelated previous runs.
+    if (this.config.mailDirectory) {
+      await this.smtp.loadMailsFromDirectory()
+      this.logger.debug('Restored persisted emails from mail directory')
+    }
+
     // 7. Set up email event handlers
     this.setupEmailHandlers()
 

--- a/packages/smtp/src/__tests__/restore.test.ts
+++ b/packages/smtp/src/__tests__/restore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MemoryStorage } from '@maildev/core'
+import { SMTPServer } from '../server.js'
+
+const EML = [
+  'From: Angelo Pappas <angelo.pappas@fbi.gov>',
+  'To: Johnny Utah <johnny.utah@fbi.gov>',
+  'Subject: The ex-presidents are surfers',
+  'Message-ID: <restore-test@example.com>',
+  'Date: Mon, 27 Jul 2026 19:46:05 +0000',
+  'MIME-Version: 1.0',
+  'Content-Type: text/plain; charset=utf-8',
+  '',
+  'The wax at the bank was surfer wax!!!',
+  '',
+].join('\r\n')
+
+describe('loadMailsFromDirectory', () => {
+  let mailDir: string
+  let storage: MemoryStorage
+  let server: SMTPServer
+
+  beforeEach(async () => {
+    mailDir = await mkdtemp(join(tmpdir(), 'maildev-restore-'))
+    storage = new MemoryStorage()
+    await storage.initialize()
+    server = new SMTPServer({ storage, mailDir })
+  })
+
+  afterEach(async () => {
+    await rm(mailDir, { recursive: true, force: true })
+  })
+
+  it('restores emails persisted as .eml files into storage', async () => {
+    await writeFile(join(mailDir, 'abc12345.eml'), EML)
+
+    expect(await storage.getAll()).toHaveLength(0)
+
+    await server.loadMailsFromDirectory()
+
+    const emails = await storage.getAll()
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.id).toBe('abc12345')
+    expect(emails[0]?.subject).toBe('The ex-presidents are surfers')
+  })
+
+  it('ignores non-.eml files', async () => {
+    await writeFile(join(mailDir, 'notes.txt'), 'not an email')
+    await writeFile(join(mailDir, 'valid.eml'), EML)
+
+    await server.loadMailsFromDirectory()
+
+    const emails = await storage.getAll()
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.id).toBe('valid')
+  })
+
+  it('does not throw when the mail directory has no emails', async () => {
+    await expect(server.loadMailsFromDirectory()).resolves.toBeUndefined()
+    expect(await storage.getAll()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

When a mail directory is configured (`--mail-directory` / `MAILDEV_MAIL_DIRECTORY`), existing `.eml` files are now loaded back into storage on startup, so mail survives a restart. Previously the files were written to disk but never read back, leaving the UI empty after a restart (e.g. a container/pod restart with a mounted volume).

## Problem

`FileStorage` persists each message as a raw `.eml` on disk, and `SMTPServer.loadMailsFromDirectory()` already knows how to re-parse and restore those files — but it was only wired to an on-demand API endpoint, never called at startup. So after a restart the directory still held every message while the UI showed none.

## Fix

The orchestrator now calls `loadMailsFromDirectory()` during startup when a mail directory is explicitly configured. The tmpdir fallback is intentionally **not** restored, to avoid resurrecting mail from unrelated previous runs.

## Tests

- New `packages/smtp/src/__tests__/restore.test.ts`: restores `.eml` files into storage, ignores non-`.eml` files, and no-ops on an empty directory.

## Verification

Sent mail with `MAILDEV_MAIL_DIRECTORY` set, stopped MailDev, restarted with the same directory — all 9 messages reappeared in `GET /api/email`.

Fixes #547