### PR TITLE
Fix Docker healthcheck for IPv6, disabled web UI, and base paths

### DIFF
--- a/.changeset/docker-healthcheck.md
+++ b/.changeset/docker-healthcheck.md
@@ -1,0 +1,9 @@
+---
+'maildev': patch
+---
+
+Fix the Docker healthcheck so containers report healthy out of the box. A dedicated healthcheck entrypoint (`dist/bin/healthcheck.js`) now:
+
+- probes `127.0.0.1` instead of `localhost`, so it no longer fails when `localhost` resolves to IPv6 (`::1`) while the web server binds IPv4 only (#537);
+- falls back to a TCP check on the SMTP port when the web UI is disabled with `--disable-web`, instead of probing an endpoint that isn't there (#544);
+- normalizes `MAILDEV_BASE_PATHNAME` so a trailing slash can't produce a `//` in the probe URL (#542).

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,5 @@ ENV MAILDEV_SMTP_PORT=1025
 
 ENTRYPOINT ["node", "dist/bin/maildev.js"]
 
-HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -q -O - "http://localhost:${MAILDEV_WEB_PORT}${MAILDEV_BASE_PATHNAME}/api/healthz" || exit 1
+HEALTHCHECK --interval=10s --timeout=5s \
+  CMD ["node", "dist/bin/healthcheck.js"]

--- a/packages/cli/src/__tests__/bin/healthcheck.test.ts
+++ b/packages/cli/src/__tests__/bin/healthcheck.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import net from 'node:net'
+import http from 'node:http'
+import { normalizeBasePath, resolveHealthcheck, runHealthcheck } from '../../bin/healthcheck.js'
+
+describe('normalizeBasePath', () => {
+  it('treats empty / root as no prefix', () => {
+    expect(normalizeBasePath(undefined)).toBe('')
+    expect(normalizeBasePath('')).toBe('')
+    expect(normalizeBasePath('/')).toBe('')
+  })
+
+  it('strips trailing slashes so the probe URL never has a double slash', () => {
+    expect(normalizeBasePath('/mail')).toBe('/mail')
+    expect(normalizeBasePath('/mail/')).toBe('/mail')
+    expect(normalizeBasePath('/mail///')).toBe('/mail')
+  })
+
+  it('adds a leading slash when missing', () => {
+    expect(normalizeBasePath('mail')).toBe('/mail')
+  })
+})
+
+describe('resolveHealthcheck', () => {
+  it('probes the web healthz endpoint on 127.0.0.1 by default (not localhost)', () => {
+    expect(resolveHealthcheck({})).toEqual({
+      mode: 'web',
+      host: '127.0.0.1',
+      port: 1080,
+      path: '/api/healthz',
+    })
+  })
+
+  it('honors the configured web port and base path', () => {
+    expect(resolveHealthcheck({ MAILDEV_WEB_PORT: '8080', MAILDEV_BASE_PATHNAME: '/mail/' })).toEqual({
+      mode: 'web',
+      host: '127.0.0.1',
+      port: 8080,
+      path: '/mail/api/healthz',
+    })
+  })
+
+  it('probes the SMTP port when the web UI is disabled', () => {
+    expect(resolveHealthcheck({ MAILDEV_DISABLE_WEB: 'true', MAILDEV_SMTP_PORT: '2525' })).toEqual({
+      mode: 'smtp',
+      host: '127.0.0.1',
+      port: 2525,
+    })
+    // both accepted truthy forms
+    expect(resolveHealthcheck({ MAILDEV_DISABLE_WEB: '1' }).mode).toBe('smtp')
+  })
+})
+
+describe('runHealthcheck (integration)', () => {
+  const servers: Array<http.Server | net.Server> = []
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map((s) => new Promise<void>((resolve) => s.close(() => resolve())))
+    )
+  })
+
+  const listen = (server: http.Server | net.Server): Promise<number> =>
+    new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        servers.push(server)
+        resolve((server.address() as net.AddressInfo).port)
+      })
+    })
+
+  it('returns true when the web healthz endpoint responds 200', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = req.url === '/api/healthz' ? 200 : 404
+      res.end()
+    })
+    const port = await listen(server)
+    expect(await runHealthcheck({ MAILDEV_WEB_PORT: String(port) })).toBe(true)
+  })
+
+  it('returns false when the web endpoint is not reachable', async () => {
+    // Nothing listening on this port.
+    expect(await runHealthcheck({ MAILDEV_WEB_PORT: '1' })).toBe(false)
+  })
+
+  it('returns true when the SMTP port accepts a connection (web disabled)', async () => {
+    const server = net.createServer((socket) => socket.end())
+    const port = await listen(server)
+    expect(
+      await runHealthcheck({ MAILDEV_DISABLE_WEB: 'true', MAILDEV_SMTP_PORT: String(port) })
+    ).toBe(true)
+  })
+})

--- a/packages/cli/src/bin/healthcheck.ts
+++ b/packages/cli/src/bin/healthcheck.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * MailDev container healthcheck
+ *
+ * Standalone entrypoint used by the Docker HEALTHCHECK. It reads the same
+ * MAILDEV_* environment variables the server uses and probes the endpoint that
+ * is actually listening:
+ *
+ *   - Web UI enabled  -> HTTP GET http://127.0.0.1:<web><basePath>/api/healthz
+ *   - Web UI disabled -> TCP connect to 127.0.0.1:<smtp>
+ *
+ * Design notes (each addresses a reported bug):
+ *   - Always targets `127.0.0.1`, never `localhost`, so it can't fail when
+ *     `localhost` resolves to IPv6 (`::1`) but the server binds IPv4 only. (#537)
+ *   - Falls back to the SMTP port when the web UI is disabled, so
+ *     `--disable-web` containers still report healthy. (#544)
+ *   - Normalizes the base path so a trailing slash can't produce a `//` in the
+ *     probe URL. (#542)
+ */
+
+import net from 'node:net'
+import http from 'node:http'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_WEB_PORT = 1080
+const DEFAULT_SMTP_PORT = 1025
+const HOST = '127.0.0.1'
+const TIMEOUT_MS = 2500
+
+export interface HealthcheckPlan {
+  mode: 'web' | 'smtp'
+  host: string
+  port: number
+  /** Request path for `web` mode. */
+  path?: string
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (value === undefined) return false
+  return value.toLowerCase() === 'true' || value === '1'
+}
+
+function parsePort(value: string | undefined, fallback: number): number {
+  const num = value ? parseInt(value, 10) : NaN
+  return Number.isNaN(num) ? fallback : num
+}
+
+/** Normalize a base pathname to `''` or `/foo` (leading slash, no trailing slash). */
+export function normalizeBasePath(raw: string | undefined): string {
+  if (!raw || raw === '/') return ''
+  let path = raw.trim()
+  if (!path.startsWith('/')) path = `/${path}`
+  return path.replace(/\/+$/, '')
+}
+
+/**
+ * Decide what to probe based on the MailDev environment configuration.
+ */
+export function resolveHealthcheck(env: NodeJS.ProcessEnv): HealthcheckPlan {
+  if (parseBoolean(env.MAILDEV_DISABLE_WEB)) {
+    return {
+      mode: 'smtp',
+      host: HOST,
+      port: parsePort(env.MAILDEV_SMTP_PORT, DEFAULT_SMTP_PORT),
+    }
+  }
+
+  const basePath = normalizeBasePath(env.MAILDEV_BASE_PATHNAME)
+  return {
+    mode: 'web',
+    host: HOST,
+    port: parsePort(env.MAILDEV_WEB_PORT, DEFAULT_WEB_PORT),
+    path: `${basePath}/api/healthz`,
+  }
+}
+
+function checkWeb(plan: HealthcheckPlan): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: plan.host, port: plan.port, path: plan.path, method: 'GET', timeout: TIMEOUT_MS },
+      (res) => {
+        res.resume() // drain
+        const status = res.statusCode ?? 0
+        resolve(status >= 200 && status < 300)
+      }
+    )
+    req.on('error', () => resolve(false))
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(false)
+    })
+    req.end()
+  })
+}
+
+function checkSmtp(plan: HealthcheckPlan): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: plan.host, port: plan.port })
+    const finish = (ok: boolean) => {
+      socket.destroy()
+      resolve(ok)
+    }
+    socket.setTimeout(TIMEOUT_MS)
+    socket.once('connect', () => finish(true))
+    socket.once('timeout', () => finish(false))
+    socket.once('error', () => finish(false))
+  })
+}
+
+/**
+ * Run the healthcheck against the given environment. Resolves `true` when the
+ * relevant MailDev service is reachable.
+ */
+export async function runHealthcheck(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
+  const plan = resolveHealthcheck(env)
+  return plan.mode === 'web' ? checkWeb(plan) : checkSmtp(plan)
+}
+
+// Run only when invoked directly as the bin entrypoint (not when imported by tests).
+const isMain = process.argv[1] !== undefined && process.argv[1] === fileURLToPath(import.meta.url)
+if (isMain) {
+  runHealthcheck()
+    .then((ok) => process.exit(ok ? 0 : 1))
+    .catch(() => process.exit(1))
+}


### PR DESCRIPTION
## Summary

Replaces the `wget`-against-`localhost` Docker healthcheck with a dedicated Node entrypoint (`dist/bin/healthcheck.js`) that reads the `MAILDEV_*` environment and probes the endpoint that is actually listening. This fixes three healthcheck failures reported against the 3.0 RC.

## Problems (all default- or common-config)

- **#537** — The web server binds IPv4-only (`0.0.0.0`) but `localhost` resolves to IPv6 (`::1`) first inside the container, so the probe got *connection refused* and the container stayed `unhealthy` (with infinite restarts on Swarm).
- **#544** — With `--disable-web` there is no HTTP server at all, so probing `/api/healthz` always failed and the container was `unhealthy`.
- **#542** — A base pathname with a trailing slash produced a `//` in the probe URL.

## Fix

New healthcheck entrypoint that:

- always targets `127.0.0.1` instead of `localhost` (can't hit the IPv6 mismatch);
- probes a **TCP connect to the SMTP port** when the web UI is disabled, instead of an HTTP endpoint that isn't there;
- normalizes `MAILDEV_BASE_PATHNAME` so a trailing slash can't produce a `//`.

The `HEALTHCHECK` in the Dockerfile now runs `node dist/bin/healthcheck.js` (exec form, no shell/wget dependency).

## Tests

New `packages/cli/src/__tests__/bin/healthcheck.test.ts` covers base-path normalization, the web-vs-SMTP resolution (incl. the `127.0.0.1` host and disabled-web fallback), and integration checks against real ephemeral HTTP/TCP servers.

## Verification

Ran the built `healthcheck.js` against a live server in all scenarios: web + base path (with and without trailing slash) → exit 0; `--disable-web` → SMTP fallback exit 0; nothing listening → exit 1.

Fixes #537, #544