### PR TITLE
Add configurable max message size to bound MIME parsing (#531)

### DIFF
--- a/.changeset/max-message-size.md
+++ b/.changeset/max-message-size.md
@@ -1,0 +1,6 @@
+---
+'@maildev/smtp': patch
+'maildev': patch
+---
+
+Add a configurable maximum message size and reject oversized messages. A new `--max-message-size` option (env `MAILDEV_MAX_MESSAGE_SIZE`, default 50 MB) advertises the SMTP SIZE extension and refuses messages larger than the limit. The bytes forwarded to the parser are capped at the limit, so a malicious multipart message with a huge number of parts can no longer tie up the parser (addresses the unbounded MIME sibling-part fanout in #531). Set to 0 to disable the limit.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,6 +67,7 @@ Usage: maildev [options]
 | `--base-pathname <path>`         | `MAILDEV_BASE_PATHNAME`    | Base path for URLs                                                                        |
 | `--disable-web`                  | `MAILDEV_DISABLE_WEB`      | Disable the use of the web interface                                                      |
 | `--hide-extensions <extensions>` | `MAILDEV_HIDE_EXTENSIONS`  | Comma separated list of SMTP extensions to NOT advertise                                  |
+| `--max-message-size <bytes>`     | `MAILDEV_MAX_MESSAGE_SIZE` | Max accepted message size in bytes; larger messages are rejected. 0 disables (default: 52428800) |
 | `--mcp`                          | `MAILDEV_MCP`              | Enable MCP server for Claude integration                                                  |
 | `--config <file>`                |                            | Path to configuration file                                                                |
 | `-v, --verbose`                  |                            | Enable verbose logging                                                                    |

--- a/packages/cli/src/__tests__/config/env.test.ts
+++ b/packages/cli/src/__tests__/config/env.test.ts
@@ -39,6 +39,14 @@ describe('loadEnvConfig', () => {
     expect(config.web).toBe(3080)
   })
 
+  it('should parse MAILDEV_MAX_MESSAGE_SIZE as number', () => {
+    process.env.MAILDEV_MAX_MESSAGE_SIZE = '1048576'
+
+    const config = loadEnvConfig()
+    expect(config.maxMessageSize).toBe(1048576)
+    expect(typeof config.maxMessageSize).toBe('number')
+  })
+
   it('should load MAILDEV_IP as string', () => {
     process.env.MAILDEV_IP = '127.0.0.1'
 

--- a/packages/cli/src/__tests__/config/validate.test.ts
+++ b/packages/cli/src/__tests__/config/validate.test.ts
@@ -63,6 +63,25 @@ describe('validateConfig', () => {
     })
   })
 
+  describe('max message size validation', () => {
+    it('should accept 0 (limit disabled)', () => {
+      const result = validateConfig(createConfig({ maxMessageSize: 0 }))
+      expect(result.valid).toBe(true)
+    })
+
+    it('should reject a negative size', () => {
+      const result = validateConfig(createConfig({ maxMessageSize: -1 }))
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.field === 'maxMessageSize')).toBe(true)
+    })
+
+    it('should reject a non-integer size', () => {
+      const result = validateConfig(createConfig({ maxMessageSize: 1.5 }))
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.field === 'maxMessageSize')).toBe(true)
+    })
+  })
+
   describe('authentication validation', () => {
     it('should require password when username is set (SMTP)', () => {
       const config = createConfig({ incomingUser: 'user' })

--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -7,6 +7,12 @@
 import type { MailDevConfig } from './types.js'
 
 /**
+ * Default maximum accepted message size (50 MB). Bounds the work done parsing a
+ * single message so a maliciously large multipart body can't tie up the server.
+ */
+export const DEFAULT_MAX_MESSAGE_SIZE = 50 * 1024 * 1024
+
+/**
  * Default configuration values
  * These match the v2 defaults exactly
  */
@@ -14,6 +20,7 @@ export const DEFAULT_CONFIG: MailDevConfig = {
   // SMTP Server
   smtp: 1025,
   ip: '::',
+  maxMessageSize: DEFAULT_MAX_MESSAGE_SIZE,
 
   // Web/API Server
   web: 1080,

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -15,6 +15,7 @@ const ENV_MAPPING: Record<string, keyof PartialMailDevConfig> = {
   MAILDEV_IP: 'ip',
   MAILDEV_INCOMING_USER: 'incomingUser',
   MAILDEV_INCOMING_PASS: 'incomingPass',
+  MAILDEV_MAX_MESSAGE_SIZE: 'maxMessageSize',
 
   // Web/API
   MAILDEV_WEB_PORT: 'web',
@@ -43,6 +44,7 @@ const NUMBER_VARS = new Set([
   'MAILDEV_SMTP_PORT',
   'MAILDEV_WEB_PORT',
   'MAILDEV_OUTGOING_PORT',
+  'MAILDEV_MAX_MESSAGE_SIZE',
 ])
 
 /**

--- a/packages/cli/src/config/merge.ts
+++ b/packages/cli/src/config/merge.ts
@@ -28,6 +28,9 @@ function cliOptionsToConfig(options: CLIOptions): PartialMailDevConfig {
   if (options.outgoingPort !== undefined) {
     config.outgoingPort = parseInt(options.outgoingPort, 10)
   }
+  if (options.maxMessageSize !== undefined) {
+    config.maxMessageSize = parseInt(options.maxMessageSize, 10)
+  }
 
   // String options
   if (options.ip !== undefined) config.ip = options.ip

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -121,6 +121,17 @@ export interface MailDevConfig {
    */
   hideExtensions?: HideableExtension[]
 
+  /**
+   * Maximum accepted message size in bytes. Larger messages are rejected
+   * before being parsed or stored. The SIZE extension is advertised so
+   * well-behaved clients skip oversized messages. Set to 0 to disable the
+   * limit.
+   * CLI: --max-message-size <bytes>
+   * Env: MAILDEV_MAX_MESSAGE_SIZE
+   * @default 52428800 (50 MB)
+   */
+  maxMessageSize: number
+
   // === Web/API Server Options ===
 
   /**
@@ -290,6 +301,7 @@ export interface CLIOptions {
   incomingCert?: string
   incomingKey?: string
   hideExtensions?: string
+  maxMessageSize?: string
   web?: string
   webIp?: string
   webUser?: string

--- a/packages/cli/src/config/validate.ts
+++ b/packages/cli/src/config/validate.ts
@@ -76,6 +76,14 @@ export function validateConfig(config: MailDevConfig): ValidationResult {
     if (outgoingPortError) errors.push(outgoingPortError)
   }
 
+  // Validate max message size (0 disables the limit)
+  if (!Number.isInteger(config.maxMessageSize) || config.maxMessageSize < 0) {
+    errors.push({
+      field: 'maxMessageSize',
+      message: 'maxMessageSize must be a non-negative integer (0 disables the limit)',
+    })
+  }
+
   // Validate TLS configuration
   if (config.incomingSecure) {
     if (!config.incomingCert) {

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -49,6 +49,10 @@ export function configureOptions(program: Command): void {
       '--hide-extensions <extensions>',
       'Comma-separated SMTP extensions to hide (STARTTLS,PIPELINING,8BITMIME,SMTPUTF8)'
     )
+    .option(
+      '--max-message-size <bytes>',
+      `Maximum accepted message size in bytes, 0 to disable (default: ${DEFAULT_CONFIG.maxMessageSize})`
+    )
 
     // === Web/API Server Options ===
     .option(
@@ -163,6 +167,7 @@ Environment Variables:
   MAILDEV_WEB_USER      Web auth username
   MAILDEV_WEB_PASS      Web auth password
   MAILDEV_MAIL_DIRECTORY Directory for persisting emails
+  MAILDEV_MAX_MESSAGE_SIZE Max accepted message size in bytes (default: 52428800)
 `
 
 /**

--- a/packages/cli/src/server/orchestrator.ts
+++ b/packages/cli/src/server/orchestrator.ts
@@ -89,6 +89,9 @@ export class Orchestrator {
     if (this.config.hideExtensions) {
       smtpOptions.hideExtensions = this.config.hideExtensions
     }
+    if (this.config.maxMessageSize !== undefined) {
+      smtpOptions.maxMessageSize = this.config.maxMessageSize
+    }
     this.smtp = createSMTPServer(smtpOptions)
 
     // 4. Configure relay if outgoing host is set

--- a/packages/smtp/src/__tests__/max-message-size.test.ts
+++ b/packages/smtp/src/__tests__/max-message-size.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import net, { type AddressInfo } from 'node:net'
+import nodemailer from 'nodemailer'
+import { MemoryStorage } from '@maildev/core'
+import { SMTPServer } from '../server.js'
+
+/** Grab an ephemeral free port so parallel test files don't collide. */
+function freePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+const MAX_SIZE = 2000
+
+describe('maxMessageSize enforcement', () => {
+  let mailDir: string
+  let storage: MemoryStorage
+  let server: SMTPServer
+  let port: number
+
+  beforeEach(async () => {
+    mailDir = await mkdtemp(join(tmpdir(), 'maildev-size-'))
+    storage = new MemoryStorage()
+    await storage.initialize()
+    port = await freePort()
+    server = new SMTPServer({ storage, mailDir, port, host: '127.0.0.1', maxMessageSize: MAX_SIZE })
+    await server.start()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+    await rm(mailDir, { recursive: true, force: true })
+  })
+
+  const send = (text: string) => {
+    const transport = nodemailer.createTransport({ host: '127.0.0.1', port, secure: false })
+    return transport.sendMail({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 'test',
+      text,
+    })
+  }
+
+  it('accepts a message under the limit and stores it', async () => {
+    await send('a short body')
+    expect(await storage.getAll()).toHaveLength(1)
+  })
+
+  it('rejects a message over the limit and stores nothing', async () => {
+    await expect(send('x'.repeat(MAX_SIZE * 4))).rejects.toThrow()
+
+    expect(await storage.getAll()).toHaveLength(0)
+    // No partial .eml file left behind for the rejected message.
+    const files = (await readdir(mailDir)).filter((f) => f.endsWith('.eml'))
+    expect(files).toHaveLength(0)
+  })
+
+  // Exercises the DATA-stream cap directly: a client that does NOT declare
+  // SIZE at MAIL FROM (as an attacker wouldn't) still gets bounded and rejected
+  // once the body runs past the limit, rather than tying up the parser.
+  it('caps and rejects an oversized body sent without a declared SIZE', async () => {
+    const boundary = 'b'
+    const part = `--${boundary}\r\nContent-Type: text/plain\r\n\r\nx\r\n`
+    const body =
+      [
+        'From: a@example.com',
+        'To: b@example.com',
+        'Subject: fanout',
+        'MIME-Version: 1.0',
+        `Content-Type: multipart/mixed; boundary="${boundary}"`,
+        '',
+        '',
+      ].join('\r\n') +
+      part.repeat(5000) + // ~200 KB, well over MAX_SIZE
+      `--${boundary}--\r\n`
+
+    const reply = await rawSmtp(port, body)
+    expect(reply).toMatch(/^552 /)
+    expect(await storage.getAll()).toHaveLength(0)
+    const files = (await readdir(mailDir)).filter((f) => f.endsWith('.eml'))
+    expect(files).toHaveLength(0)
+  })
+})
+
+/**
+ * Minimal raw SMTP client that delivers `body` without declaring SIZE, and
+ * resolves with the final reply to end-of-DATA.
+ */
+function rawSmtp(port: number, body: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(port, '127.0.0.1')
+    sock.setEncoding('utf8')
+    sock.setTimeout(10000, () => {
+      sock.destroy()
+      reject(new Error('SMTP timeout'))
+    })
+    const script = ['EHLO test', 'MAIL FROM:<a@example.com>', 'RCPT TO:<b@example.com>', 'DATA']
+    let buf = ''
+    const waiters: Array<(reply: string) => void> = []
+    const pump = () => {
+      const m = buf.match(/^\d{3} [^\r\n]*\r\n/m)
+      if (m && waiters.length) {
+        const end = buf.indexOf(m[0]) + m[0].length
+        const reply = buf.slice(0, end).trim()
+        buf = buf.slice(end)
+        waiters.shift()!(reply)
+      }
+    }
+    const expectReply = () => new Promise<string>((res) => { waiters.push(res); pump() })
+    sock.on('data', (d) => { buf += d; pump() })
+    sock.on('error', reject)
+    ;(async () => {
+      await expectReply() // greeting
+      for (const line of script) {
+        sock.write(line + '\r\n')
+        await expectReply()
+      }
+      sock.write(body + '\r\n.\r\n')
+      const final = await expectReply()
+      sock.write('QUIT\r\n')
+      sock.end()
+      resolve(final)
+    })().catch(reject)
+  })
+}

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -11,7 +11,7 @@ import { createReadStream, createWriteStream, existsSync, mkdirSync, statSync, r
 import { rm, readdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
-import { PassThrough, type Readable } from 'node:stream'
+import { PassThrough, Transform, type Readable } from 'node:stream'
 import { formatBytes, calculateBcc, makeId, type Storage, type Email, type Attachment } from '@maildev/core'
 import { parseEmailStream, parseEmailBuffer } from './parser.js'
 import { createAuthCallback } from './auth.js'
@@ -411,6 +411,14 @@ export class SMTPServer extends EventEmitter {
       disabledCommands: ['AUTH'] as string[],
     }
 
+    // Advertise and enforce a maximum message size. smtp-server rejects
+    // messages that declare an oversized SIZE at MAIL FROM, and flags the DATA
+    // stream with `sizeExceeded` when the body itself runs over (see
+    // processIncomingEmail). 0/undefined disables the limit.
+    if (this.options.maxMessageSize && this.options.maxMessageSize > 0) {
+      config.size = this.options.maxMessageSize
+    }
+
     // Load TLS certificates
     if (this.options.certPath) {
       config.cert = readFileSync(this.options.certPath)
@@ -477,19 +485,43 @@ export class SMTPServer extends EventEmitter {
     const id = makeId()
     const emlPath = join(this.mailDir, `${id}.eml`)
 
+    // Cap the bytes forwarded to the writer/parser at maxMessageSize. This
+    // bounds the work spent parsing a single message regardless of how much
+    // DATA the client actually sends, which is what stops a malicious multipart
+    // body with a huge number of parts from tying up the parser. The cap keeps
+    // draining the source after the limit (so the SMTP DATA command still
+    // completes) and records that the message was truncated so it can be
+    // rejected below. Well-behaved clients that declare an oversized SIZE are
+    // already refused earlier by smtp-server's `size` option.
+    const limit = this.options.maxMessageSize && this.options.maxMessageSize > 0
+      ? this.options.maxMessageSize
+      : 0
+    const sizeState = { exceeded: false }
+    const source = limit ? stream.pipe(this.createSizeCap(limit, sizeState)) : stream
+
     // Create two pass-through streams to duplicate the data
     const emlPassThrough = new PassThrough()
     const parsePassThrough = new PassThrough()
 
     // Pipe to both streams
-    stream.pipe(emlPassThrough)
-    stream.pipe(parsePassThrough)
+    source.pipe(emlPassThrough)
+    source.pipe(parsePassThrough)
 
     // Write to disk and parse in parallel
     const [, parsed] = await Promise.all([
       pipeline(emlPassThrough, createWriteStream(emlPath)),
       parseEmailStream(parsePassThrough),
     ])
+
+    // Reject messages that ran past the size limit. The file only holds the
+    // truncated prefix, so discard it and refuse the message rather than storing
+    // a partial.
+    if (sizeState.exceeded) {
+      await rm(emlPath, { force: true })
+      const error = new Error('Message exceeds maximum allowed size') as Error & { responseCode?: number }
+      error.responseCode = 552 // permanent: exceeded storage allocation
+      throw error
+    }
 
     // Save attachments
     if (parsed.attachments && parsed.attachments.length > 0) {
@@ -516,6 +548,31 @@ export class SMTPServer extends EventEmitter {
     await this.saveEmail(id, envelope, parsed)
 
     return id
+  }
+
+  /**
+   * Build a Transform that forwards at most `limit` bytes downstream and then
+   * keeps draining its input (so the source stream can finish) while dropping
+   * the excess. Sets `state.exceeded` once the limit is crossed.
+   */
+  private createSizeCap(limit: number, state: { exceeded: boolean }): Transform {
+    let bytes = 0
+    return new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        if (state.exceeded) {
+          callback() // already over the limit: drain and drop
+          return
+        }
+        bytes += chunk.length
+        if (bytes > limit) {
+          state.exceeded = true
+          const allowed = chunk.length - (bytes - limit)
+          callback(null, allowed > 0 ? chunk.subarray(0, allowed) : undefined)
+          return
+        }
+        callback(null, chunk)
+      },
+    })
   }
 
   /**

--- a/packages/smtp/src/types.ts
+++ b/packages/smtp/src/types.ts
@@ -29,6 +29,12 @@ export interface SMTPServerOptions {
   auth?: SMTPAuth
   /** SMTP extensions to hide */
   hideExtensions?: HideableExtension[]
+  /**
+   * Maximum accepted message size in bytes. Larger messages are rejected
+   * before being stored. Advertised via the SMTP SIZE extension. 0 or
+   * undefined disables the limit.
+   */
+  maxMessageSize?: number
   /** Auto-relay configuration */
   autoRelay?: AutoRelayConfig
   /** Logger instance or false to disable */


### PR DESCRIPTION
## Summary

Adds a configurable maximum message size and rejects oversized messages, addressing the unbounded MIME sibling-part fanout DoS in #531. New option `--max-message-size` (env `MAILDEV_MAX_MESSAGE_SIZE`), default **50 MB**. Set to `0` to disable.

## Problem

MailDev piped the entire SMTP DATA stream into `simpleParser` with no size limit. A multipart message with a very large number of sibling parts made the parser build and walk every node, keeping the process busy. Because `smtp-server` flags an oversized stream but keeps *emitting* it, a naive size check would still let the parser process the whole payload.

## Fix

- **Advertise SIZE**: sets `smtp-server`'s `size` option, so well-behaved clients that declare an oversized `SIZE` are refused at `MAIL FROM`.
- **Cap the parser input**: a small `Transform` forwards at most `maxMessageSize` bytes to the writer/parser and then drains the rest. A client that omits or under-declares `SIZE` is still bounded — parsing never processes more than the limit — and the truncated message is rejected (`552`) and not stored.

Threaded through config (CLI flag, env var, validation, defaults) and the orchestrator into `@maildev/smtp`.

## Tests

New `packages/smtp/src/__tests__/max-message-size.test.ts`:
- accepts an under-limit message;
- rejects an over-limit message (via nodemailer, the SIZE path) and leaves no stored email or partial `.eml`;
- **raw-socket test** that omits `SIZE` and sends an oversized multipart body — exercises the cap directly, expects a `552` and nothing stored.

Plus CLI env-parsing and validation tests.

## Verification

A 300k-part / ~10 MB fanout sent over a raw socket *without* a declared `SIZE` is now rejected with `552` in ~220 ms (parser bounded by the cap) and not stored, while normal mail continues to be accepted. Benchmarking confirmed `mailparser@3.9.14` is roughly linear, so the byte cap directly bounds parse work.

## Note on the default

Default is 50 MB (generous for large-attachment test emails while still bounding the worst case). At 50 MB a pure-fanout body is bounded to ~a few seconds of parse time; lowering `--max-message-size` tightens this further. This is a minor behavior change for the RC — messages larger than 50 MB now get a `552` unless the limit is raised or disabled.

Fixes #531