### PR TITLE
Improve loading bar and DOM testability (#541)

### DIFF
--- a/.changeset/ui-loading-testability.md
+++ b/.changeset/ui-loading-testability.md
@@ -1,0 +1,8 @@
+---
+'@maildev/ui': patch
+---
+
+Make the top loading bar less disruptive and improve DOM testability.
+
+- The loading bar shown during background refreshes is now kept mounted and toggled via opacity instead of being added to and removed from the DOM every poll cycle, so it no longer causes a reflow every few seconds. A new "Show loading bar" toggle in Settings lets you turn it off entirely.
+- Added stable `data-testid` attributes to key elements (header actions, search input, email list and rows — including `data-email-id` — the email viewer, subject, attachments, and the loading bar) so automated UI tests no longer need to rely on fragile positional selectors.

--- a/packages/ui/src/components/email-list/EmailList.tsx
+++ b/packages/ui/src/components/email-list/EmailList.tsx
@@ -8,7 +8,10 @@ export function EmailList() {
 
   if (isLoading) {
     return (
-      <div className="flex h-32 items-center justify-center text-[hsl(var(--muted-foreground))]">
+      <div
+        data-testid="email-list-loading"
+        className="flex h-32 items-center justify-center text-[hsl(var(--muted-foreground))]"
+      >
         <svg
           className="mr-2 h-5 w-5 animate-spin"
           fill="none"
@@ -35,7 +38,10 @@ export function EmailList() {
 
   if (error) {
     return (
-      <div className="flex h-32 items-center justify-center text-[hsl(var(--destructive))]">
+      <div
+        data-testid="email-list-error"
+        className="flex h-32 items-center justify-center text-[hsl(var(--destructive))]"
+      >
         Failed to load emails
       </div>
     )
@@ -43,7 +49,10 @@ export function EmailList() {
 
   if (!emails || emails.length === 0) {
     return (
-      <div className="flex h-32 flex-col items-center justify-center gap-2 text-[hsl(var(--muted-foreground))]">
+      <div
+        data-testid="email-list-empty"
+        className="flex h-32 flex-col items-center justify-center gap-2 text-[hsl(var(--muted-foreground))]"
+      >
         <svg
           className="h-8 w-8"
           fill="none"
@@ -75,14 +84,17 @@ export function EmailList() {
 
   if (sortedEmails.length === 0) {
     return (
-      <div className="flex h-32 items-center justify-center text-[hsl(var(--muted-foreground))]">
+      <div
+        data-testid="email-list-no-results"
+        className="flex h-32 items-center justify-center text-[hsl(var(--muted-foreground))]"
+      >
         <span className="text-sm">No emails match "{searchQuery}"</span>
       </div>
     )
   }
 
   return (
-    <div className="divide-y divide-[hsl(var(--border))]">
+    <div data-testid="email-list" className="divide-y divide-[hsl(var(--border))]">
       {sortedEmails.map((email) => (
         <EmailListItem key={email.id} email={email} />
       ))}

--- a/packages/ui/src/components/email-list/EmailListItem.tsx
+++ b/packages/ui/src/components/email-list/EmailListItem.tsx
@@ -18,6 +18,10 @@ export function EmailListItem({ email }: EmailListItemProps) {
   return (
     <button
       onClick={() => setSelectedEmail(email.id)}
+      data-testid="email-list-item"
+      data-email-id={email.id}
+      data-selected={isSelected}
+      data-read={email.read}
       className={cn(
         'w-full px-3 py-3 text-left transition-colors',
         'hover:bg-[hsl(var(--muted)/0.5)]',

--- a/packages/ui/src/components/email-list/SearchInput.tsx
+++ b/packages/ui/src/components/email-list/SearchInput.tsx
@@ -78,6 +78,7 @@ export function SearchInput() {
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         placeholder="Search emails..."
+        data-testid="search-input"
         className={cn(
           'w-full rounded-md border border-[hsl(var(--input))] bg-[hsl(var(--background))]',
           'py-2 pl-10 pr-10 text-sm',
@@ -99,6 +100,7 @@ export function SearchInput() {
               onClick={() => setSearchQuery('')}
               className="rounded-sm p-0.5 hover:bg-[hsl(var(--muted))]"
               aria-label="Clear search"
+              data-testid="search-clear-button"
             >
               <svg
                 className="h-4 w-4 text-[hsl(var(--muted-foreground))]"

--- a/packages/ui/src/components/email-viewer/EmailHeader.tsx
+++ b/packages/ui/src/components/email-viewer/EmailHeader.tsx
@@ -111,7 +111,7 @@ export function EmailHeader({ email }: EmailHeaderProps) {
 
           {/* Email info */}
           <div className="min-w-0 flex-1">
-            <h1 className="text-lg font-semibold text-[hsl(var(--foreground))]">
+            <h1 data-testid="email-subject" className="text-lg font-semibold text-[hsl(var(--foreground))]">
               {email.subject || '(no subject)'}
             </h1>
             <div className="mt-1 text-sm text-[hsl(var(--muted-foreground))]">
@@ -155,6 +155,7 @@ export function EmailHeader({ email }: EmailHeaderProps) {
               onClick={handleDownload}
               className="rounded-md p-2 hover:bg-[hsl(var(--muted))]"
               aria-label="Download email"
+              data-testid="download-email-button"
             >
               <svg
                 className="h-4 w-4"
@@ -299,6 +300,7 @@ export function EmailHeader({ email }: EmailHeaderProps) {
                 'disabled:cursor-not-allowed disabled:opacity-50'
               )}
               aria-label="Delete email"
+              data-testid="delete-email-button"
             >
               <svg
                 className="h-4 w-4"
@@ -320,13 +322,14 @@ export function EmailHeader({ email }: EmailHeaderProps) {
 
       {/* Attachments */}
       {email.attachments && email.attachments.length > 0 && (
-        <div className="mt-3 flex flex-wrap gap-2">
+        <div data-testid="email-attachments" className="mt-3 flex flex-wrap gap-2">
           {email.attachments.map((attachment, index) => (
             <Tooltip key={index} content={`Download ${attachment.filename ?? 'attachment'}`}>
               <a
                 href={api.emails.attachmentUrl(email.id, attachment.generatedFileName)}
                 target="_blank"
                 rel="noopener noreferrer"
+                data-testid="email-attachment"
                 className={cn(
                   'inline-flex items-center gap-1.5 rounded-md border border-[hsl(var(--border))]',
                   'px-2 py-1 text-xs text-[hsl(var(--foreground))]',

--- a/packages/ui/src/components/email-viewer/EmailViewer.tsx
+++ b/packages/ui/src/components/email-viewer/EmailViewer.tsx
@@ -9,7 +9,10 @@ export function EmailViewer() {
 
   if (!selectedEmailId) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 text-[hsl(var(--muted-foreground))]">
+      <div
+        data-testid="email-viewer-empty"
+        className="flex h-full flex-col items-center justify-center gap-3 text-[hsl(var(--muted-foreground))]"
+      >
         <svg
           className="h-16 w-16"
           fill="none"
@@ -30,7 +33,10 @@ export function EmailViewer() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center text-[hsl(var(--muted-foreground))]">
+      <div
+        data-testid="email-viewer-loading"
+        className="flex h-full items-center justify-center text-[hsl(var(--muted-foreground))]"
+      >
         <svg
           className="mr-2 h-5 w-5 animate-spin"
           fill="none"
@@ -57,14 +63,17 @@ export function EmailViewer() {
 
   if (error || !email) {
     return (
-      <div className="flex h-full items-center justify-center text-[hsl(var(--destructive))]">
+      <div
+        data-testid="email-viewer-error"
+        className="flex h-full items-center justify-center text-[hsl(var(--destructive))]"
+      >
         Failed to load email
       </div>
     )
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div data-testid="email-viewer" data-email-id={email.id} className="flex h-full flex-col">
       <EmailHeader email={email} />
       <EmailContent email={email} />
     </div>

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -20,6 +20,8 @@ export function Header() {
   const setNotificationsEnabled = useUIStore((state) => state.setNotificationsEnabled)
   const autoShowNewMail = useUIStore((state) => state.autoShowNewMail)
   const setAutoShowNewMail = useUIStore((state) => state.setAutoShowNewMail)
+  const loadingBarEnabled = useUIStore((state) => state.loadingBarEnabled)
+  const setLoadingBarEnabled = useUIStore((state) => state.setLoadingBarEnabled)
 
   // Check if notifications are supported
   const notificationsSupported = typeof window !== 'undefined' && 'Notification' in window
@@ -63,13 +65,17 @@ export function Header() {
   }
 
   return (
-    <header className="flex h-14 items-center justify-between border-b border-[hsl(var(--border))] bg-[hsl(var(--background))] px-4">
+    <header
+      data-testid="header"
+      className="flex h-14 items-center justify-between border-b border-[hsl(var(--border))] bg-[hsl(var(--background))] px-4"
+    >
       <div className="flex items-center gap-3">
         <Tooltip content="Toggle sidebar (s)">
           <button
             onClick={toggleSidebar}
             className="rounded-md p-2 hover:bg-[hsl(var(--muted))]"
             aria-label="Toggle sidebar"
+            data-testid="toggle-sidebar-button"
           >
             <svg
               className="h-5 w-5"
@@ -108,6 +114,7 @@ export function Header() {
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             aria-label="Refresh emails"
+            data-testid="refresh-button"
           >
             <svg
               className={cn('h-4 w-4', isRefreshing && 'animate-spin')}
@@ -136,6 +143,7 @@ export function Header() {
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             aria-label="Mark all as read"
+            data-testid="mark-all-read-button"
           >
             <svg
               className="h-4 w-4"
@@ -164,6 +172,7 @@ export function Header() {
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             aria-label="Delete all emails"
+            data-testid="delete-all-button"
           >
             <svg
               className="h-4 w-4"
@@ -187,6 +196,7 @@ export function Header() {
             onClick={toggleTheme}
             className="rounded-md p-2 hover:bg-[hsl(var(--muted))]"
             aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+            data-testid="theme-toggle"
           >
             {theme === 'light' ? (
               <svg
@@ -227,6 +237,7 @@ export function Header() {
               onClick={() => setShowSettings(!showSettings)}
               className="rounded-md p-2 hover:bg-[hsl(var(--muted))]"
               aria-label="Settings"
+              data-testid="settings-button"
             >
               <svg
                 className="h-5 w-5"
@@ -252,7 +263,10 @@ export function Header() {
 
           {/* Settings menu */}
           {showSettings && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] py-1 shadow-lg">
+            <div
+              data-testid="settings-menu"
+              className="absolute right-0 top-full z-50 mt-1 w-64 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] py-1 shadow-lg"
+            >
               {/* Browser notifications */}
               <button
                 onClick={handleNotificationsToggle}
@@ -262,6 +276,7 @@ export function Header() {
                   'hover:bg-[hsl(var(--muted))]',
                   (!notificationsSupported || !isSecureContext) && 'cursor-not-allowed opacity-50'
                 )}
+                data-testid="notifications-toggle"
               >
                 <div className="flex items-center gap-2">
                   <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -300,6 +315,7 @@ export function Header() {
               <button
                 onClick={() => setAutoShowNewMail(!autoShowNewMail)}
                 className="flex w-full items-center justify-between px-3 py-2 text-sm hover:bg-[hsl(var(--muted))]"
+                data-testid="auto-show-new-mail-toggle"
               >
                 <div className="flex items-center gap-2">
                   <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -330,6 +346,40 @@ export function Header() {
                     className={cn(
                       'h-4 w-4 rounded-full bg-white shadow transition-transform mt-0.5',
                       autoShowNewMail ? 'translate-x-4 ml-0.5' : 'translate-x-0.5'
+                    )}
+                  />
+                </div>
+              </button>
+
+              {/* Loading bar */}
+              <button
+                onClick={() => setLoadingBarEnabled(!loadingBarEnabled)}
+                className="flex w-full items-center justify-between px-3 py-2 text-sm hover:bg-[hsl(var(--muted))]"
+                data-testid="loading-bar-toggle"
+              >
+                <div className="flex items-center gap-2">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 10V3L4 14h7v7l9-11h-7z"
+                    />
+                  </svg>
+                  <span>Show loading bar</span>
+                </div>
+                <div
+                  className={cn(
+                    'h-5 w-9 rounded-full transition-colors',
+                    loadingBarEnabled
+                      ? 'bg-blue-600 dark:bg-blue-500'
+                      : 'bg-gray-300 dark:bg-gray-600'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'h-4 w-4 rounded-full bg-white shadow transition-transform mt-0.5',
+                      loadingBarEnabled ? 'translate-x-4 ml-0.5' : 'translate-x-0.5'
                     )}
                   />
                 </div>

--- a/packages/ui/src/components/layout/Layout.test.tsx
+++ b/packages/ui/src/components/layout/Layout.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+// Control the refresh state the loading bar reacts to.
+const state = vi.hoisted(() => ({ isRefreshing: false }))
+
+vi.mock('../../hooks/useSocket', () => ({ useSocket: () => undefined }))
+vi.mock('../../hooks/useEmails', () => ({
+  useRefreshEmails: () => ({ isRefreshing: state.isRefreshing, refresh: () => undefined }),
+}))
+// Stub the heavy children so we only exercise Layout's own markup.
+vi.mock('./Header', () => ({ Header: () => <div data-testid="header-stub" /> }))
+vi.mock('./Sidebar', () => ({ Sidebar: () => <div data-testid="sidebar-stub" /> }))
+vi.mock('../email-viewer/EmailViewer', () => ({ EmailViewer: () => <div data-testid="viewer-stub" /> }))
+
+import { Layout } from './Layout'
+import { useUIStore } from '../../stores/ui'
+
+afterEach(() => {
+  cleanup()
+  state.isRefreshing = false
+  useUIStore.setState({ loadingBarEnabled: true })
+})
+
+describe('Layout loading bar', () => {
+  it('stays mounted (but hidden) when idle, so background refreshes do not add/remove a node', () => {
+    state.isRefreshing = false
+    render(<Layout />)
+
+    const bar = screen.getByTestId('loading-bar')
+    expect(bar).toBeTruthy()
+    expect(bar.getAttribute('data-active')).toBe('false')
+    expect(bar.className).toContain('opacity-0')
+  })
+
+  it('becomes visible via opacity (not remount) while refreshing', () => {
+    state.isRefreshing = true
+    render(<Layout />)
+
+    const bar = screen.getByTestId('loading-bar')
+    expect(bar.getAttribute('data-active')).toBe('true')
+    expect(bar.className).toContain('opacity-100')
+  })
+
+  it('is removed entirely when disabled in settings', () => {
+    useUIStore.setState({ loadingBarEnabled: false })
+    render(<Layout />)
+
+    expect(screen.queryByTestId('loading-bar')).toBeNull()
+  })
+})

--- a/packages/ui/src/components/layout/Layout.tsx
+++ b/packages/ui/src/components/layout/Layout.tsx
@@ -12,6 +12,7 @@ export function Layout() {
   useSocket()
 
   const sidebarCollapsed = useUIStore((state) => state.sidebarCollapsed)
+  const loadingBarEnabled = useUIStore((state) => state.loadingBarEnabled)
   const { isRefreshing } = useRefreshEmails()
 
   // Keep loading bar visible for minimum time so it's noticeable
@@ -28,16 +29,30 @@ export function Layout() {
   }, [isRefreshing, showLoadingBar])
 
   return (
-    <div className="flex h-screen flex-col bg-[hsl(var(--background))]">
-      {/* Global loading bar */}
-      {showLoadingBar && (
-        <div className="absolute top-0 left-0 right-0 z-50 h-0.5 overflow-hidden bg-[hsl(var(--primary)/0.2)]">
+    <div
+      data-testid="app"
+      className="flex h-screen flex-col bg-[hsl(var(--background))]"
+    >
+      {/* Global loading bar. Kept mounted and toggled via opacity so background
+          refreshes don't add/remove a DOM node (which caused a reflow every few
+          seconds). Can be turned off entirely in Settings. */}
+      {loadingBarEnabled && (
+        <div
+          data-testid="loading-bar"
+          data-active={showLoadingBar}
+          aria-hidden={!showLoadingBar}
+          className={cn(
+            'pointer-events-none absolute top-0 left-0 right-0 z-50 h-0.5 overflow-hidden bg-[hsl(var(--primary)/0.2)] transition-opacity duration-200',
+            showLoadingBar ? 'opacity-100' : 'opacity-0'
+          )}
+        >
           <div className="h-full w-1/3 animate-loading-bar bg-[hsl(var(--primary))]" />
         </div>
       )}
       <Header />
       <div className="flex flex-1 overflow-hidden">
         <aside
+          data-testid="sidebar-container"
           className={cn(
             'flex-shrink-0 overflow-hidden border-r border-[hsl(var(--border))] transition-all duration-200',
             sidebarCollapsed ? 'w-0 border-r-0' : 'w-80 lg:w-96'
@@ -45,7 +60,7 @@ export function Layout() {
         >
           <Sidebar />
         </aside>
-        <main className="flex-1 overflow-hidden">
+        <main data-testid="email-viewer-pane" className="flex-1 overflow-hidden">
           <EmailViewer />
         </main>
       </div>

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -7,11 +7,14 @@ export function Sidebar() {
   const unreadCount = emails?.filter((e) => !e.read).length ?? 0
 
   return (
-    <div className="flex h-full flex-col">
+    <div data-testid="sidebar" className="flex h-full flex-col">
       <div className="border-b border-[hsl(var(--border))] p-3">
         <SearchInput />
         {emails && emails.length > 0 && (
-          <div className="mt-2 flex items-center gap-2 text-xs text-[hsl(var(--muted-foreground))]">
+          <div
+            data-testid="email-count"
+            className="mt-2 flex items-center gap-2 text-xs text-[hsl(var(--muted-foreground))]"
+          >
             <span>{emails.length} email{emails.length !== 1 ? 's' : ''}</span>
             {unreadCount > 0 && (
               <>

--- a/packages/ui/src/stores/ui.test.ts
+++ b/packages/ui/src/stores/ui.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from './ui'
+
+describe('ui store — loadingBarEnabled', () => {
+  beforeEach(() => {
+    useUIStore.setState({ loadingBarEnabled: true })
+  })
+
+  it('defaults to enabled', () => {
+    expect(useUIStore.getState().loadingBarEnabled).toBe(true)
+  })
+
+  it('can be toggled off and on', () => {
+    useUIStore.getState().setLoadingBarEnabled(false)
+    expect(useUIStore.getState().loadingBarEnabled).toBe(false)
+
+    useUIStore.getState().setLoadingBarEnabled(true)
+    expect(useUIStore.getState().loadingBarEnabled).toBe(true)
+  })
+})

--- a/packages/ui/src/stores/ui.ts
+++ b/packages/ui/src/stores/ui.ts
@@ -14,6 +14,8 @@ interface UIState {
   notificationsEnabled: boolean
   /** Auto-show new emails when they arrive */
   autoShowNewMail: boolean
+  /** Show the top loading bar during background refreshes */
+  loadingBarEnabled: boolean
   /** Command palette open state */
   commandPaletteOpen: boolean
 
@@ -25,6 +27,7 @@ interface UIState {
   toggleSidebar: () => void
   setNotificationsEnabled: (enabled: boolean) => void
   setAutoShowNewMail: (enabled: boolean) => void
+  setLoadingBarEnabled: (enabled: boolean) => void
   openCommandPalette: () => void
   closeCommandPalette: () => void
 }
@@ -38,6 +41,7 @@ export const useUIStore = create<UIState>()(
       sidebarCollapsed: false,
       notificationsEnabled: false,
       autoShowNewMail: false,
+      loadingBarEnabled: true,
       commandPaletteOpen: false,
 
       setSelectedEmail: (id) => set({ selectedEmailId: id }),
@@ -60,6 +64,8 @@ export const useUIStore = create<UIState>()(
 
       setAutoShowNewMail: (enabled) => set({ autoShowNewMail: enabled }),
 
+      setLoadingBarEnabled: (enabled) => set({ loadingBarEnabled: enabled }),
+
       openCommandPalette: () => set({ commandPaletteOpen: true }),
 
       closeCommandPalette: () => set({ commandPaletteOpen: false }),
@@ -71,6 +77,7 @@ export const useUIStore = create<UIState>()(
         sidebarCollapsed: state.sidebarCollapsed,
         notificationsEnabled: state.notificationsEnabled,
         autoShowNewMail: state.autoShowNewMail,
+        loadingBarEnabled: state.loadingBarEnabled,
       }),
     }
   )


### PR DESCRIPTION
## Summary

Addresses both parts of #541: the distracting top loading bar, and the lack of stable selectors for automated UI testing.

## Loading bar

Previously the top loading bar was **conditionally mounted/unmounted** (`{showLoadingBar && <div/>}`) on every background refresh — and the app polls emails every ~5s — so a DOM node was added and removed every few seconds, causing a reflow.

Now the bar is **always mounted and toggled via opacity** (`opacity-0`/`opacity-100` with a transition), so background refreshes no longer add/remove a node. A new **"Show loading bar"** toggle in Settings (persisted, on by default) lets users turn it off entirely, as the issue suggested.

## Testability

Added stable `data-testid` attributes to the key elements (no prior convention existed — grep for `data-testid` returned nothing):

- Header actions: `refresh-button`, `mark-all-read-button`, `delete-all-button`, `theme-toggle`, `settings-button`, `toggle-sidebar-button`, and the settings toggles.
- `search-input` / `search-clear-button`, `sidebar`, `email-count`.
- `email-list` and each row as `email-list-item` with `data-email-id`, `data-selected`, `data-read`; plus the loading/empty/error/no-results states.
- `email-viewer` (+ `data-email-id`), `email-subject`, `email-attachments` / `email-attachment`, and the viewer action buttons.
- `loading-bar` with a `data-active` attribute reflecting its state.

## Tests

- `src/stores/ui.test.ts` — the new `loadingBarEnabled` setting defaults on and toggles.
- `src/components/layout/Layout.test.tsx` — the loading bar stays **mounted but hidden** when idle (the core fix), becomes visible via opacity while refreshing, and is removed entirely when disabled.

Full UI suite: 22 passing (was 17). typecheck, lint, and build all pass.

Fixes #541