### PR TITLE
Fix iframe resize regressions in email preview (follow-up to #538)

### DIFF
--- a/.changeset/fix-email-preview-iframe-resize.md
+++ b/.changeset/fix-email-preview-iframe-resize.md
@@ -2,6 +2,9 @@
 '@maildev/ui': patch
 ---
 
-Fix HTML email preview iframe sizing: re-measure on viewport change (previously
-switching viewport permanently disabled dynamic height and keyboard forwarding),
-and let the height shrink back to fit shorter content.
+Fix HTML email preview iframe sizing on viewport change. Switching the preview
+viewport previously left it permanently broken — the iframe stopped resizing to
+its content (tall emails were clipped and the footer became unreachable) and
+in-iframe keyboard shortcuts stopped forwarding — because the resize observers
+and listeners were torn down and never re-attached. They are now kept in place
+across viewport changes and the height is re-measured for the new width.

--- a/.changeset/fix-email-preview-iframe-resize.md
+++ b/.changeset/fix-email-preview-iframe-resize.md
@@ -1,0 +1,7 @@
+---
+'@maildev/ui': patch
+---
+
+Fix HTML email preview iframe sizing: re-measure on viewport change (previously
+switching viewport permanently disabled dynamic height and keyboard forwarding),
+and let the height shrink back to fit shorter content.

--- a/packages/ui/src/components/email-viewer/EmailContent.test.ts
+++ b/packages/ui/src/components/email-viewer/EmailContent.test.ts
@@ -36,6 +36,20 @@ describe('getEmailDocumentHeight', () => {
     expect(getEmailDocumentHeight(doc)).toBe(1200)
   })
 
+  it('ignores documentElement.clientHeight so it can shrink back to content', () => {
+    const doc = document.implementation.createHTMLDocument('email')
+
+    // clientHeight reflects the iframe's own (previously set) viewport height,
+    // not the content. A shorter email must not stay pinned to the old height.
+    setMetric(doc.documentElement, 'clientHeight', 2000)
+    setMetric(doc.documentElement, 'scrollHeight', 400)
+    setMetric(doc.documentElement, 'offsetHeight', 400)
+    setMetric(doc.body, 'scrollHeight', 400)
+    setMetric(doc.body, 'offsetHeight', 400)
+
+    expect(getEmailDocumentHeight(doc)).toBe(400)
+  })
+
   it('accounts for content extending beyond body scroll height', () => {
     const doc = document.implementation.createHTMLDocument('email')
     const footer = doc.createElement('footer')

--- a/packages/ui/src/components/email-viewer/EmailContent.tsx
+++ b/packages/ui/src/components/email-viewer/EmailContent.tsx
@@ -259,10 +259,10 @@ function HtmlContent({ html, viewport }: { html: string | undefined; viewport: s
 
   // Changing the viewport only resizes the existing iframe; it does NOT reload
   // it, so onLoad never fires again. Keep the already-attached listeners in
-  // place and just re-measure for the new width (resetting first so switching
-  // to a wider viewport can shrink the height back down).
+  // place and just re-measure for the new width. (We deliberately do NOT reset
+  // the height to null first: the reset raced the measurement rAF so it never
+  // shrank anyway, and it caused a one-frame collapse that lost scroll position.)
   useEffect(() => {
-    setIframeHeight(null)
     scheduleIframeResize()
   }, [scheduleIframeResize, viewport])
 

--- a/packages/ui/src/components/email-viewer/EmailContent.tsx
+++ b/packages/ui/src/components/email-viewer/EmailContent.tsx
@@ -190,11 +190,14 @@ export function getEmailDocumentHeight(doc: Document): number {
   const bodyStyle = doc.defaultView?.getComputedStyle(body)
   const bodyMarginBottom = bodyStyle ? parseFloat(bodyStyle.marginBottom) || 0 : 0
 
+  // NB: documentElement.clientHeight is intentionally omitted — for the root
+  // element it reports the iframe's own viewport height (i.e. whatever height
+  // we last set), which would ratchet the measurement up and prevent it from
+  // ever shrinking to fit shorter content.
   return Math.ceil(
     Math.max(
       documentElement.scrollHeight,
       documentElement.offsetHeight,
-      documentElement.clientHeight,
       body.scrollHeight,
       body.offsetHeight,
       childBottom + bodyMarginBottom
@@ -246,15 +249,26 @@ function HtmlContent({ html, viewport }: { html: string | undefined; viewport: s
 
   useEffect(() => cleanupIframe, [cleanupIframe])
 
+  // Changing the email swaps the iframe's srcDoc, which reloads it and fires
+  // onLoad -> handleIframeLoad re-attaches listeners. Reset the height so the
+  // new content is measured from scratch.
   useEffect(() => {
     cleanupIframe()
     setIframeHeight(null)
-  }, [cleanupIframe, html, viewport])
+  }, [cleanupIframe, html])
 
-  // Forward keyboard shortcuts from iframe to parent window
-  const handleIframeLoad = () => {
-    cleanupIframe()
+  // Changing the viewport only resizes the existing iframe; it does NOT reload
+  // it, so onLoad never fires again. Keep the already-attached listeners in
+  // place and just re-measure for the new width (resetting first so switching
+  // to a wider viewport can shrink the height back down).
+  useEffect(() => {
+    setIframeHeight(null)
+    scheduleIframeResize()
+  }, [scheduleIframeResize, viewport])
 
+  // Forward keyboard shortcuts from iframe to parent window and observe the
+  // loaded document so the iframe height tracks its content.
+  const setupIframe = useCallback(() => {
     const iframe = iframeRef.current
     const iframeWindow = iframe?.contentWindow
     const iframeDocument = iframe?.contentDocument
@@ -319,7 +333,18 @@ function HtmlContent({ html, viewport }: { html: string | undefined; viewport: s
           fonts?: { ready?: Promise<unknown> }
         }
       ).fonts
-      fonts?.ready?.then(scheduleIframeResize).catch(() => undefined)
+      // A promise can't be cancelled, so gate the callback behind a disposed
+      // flag tied to this iframe's cleanup — otherwise a late font load could
+      // resize a torn-down or already-replaced iframe.
+      let fontsDisposed = false
+      cleanupCallbacks.push(() => {
+        fontsDisposed = true
+      })
+      fonts?.ready
+        ?.then(() => {
+          if (!fontsDisposed) scheduleIframeResize()
+        })
+        .catch(() => undefined)
     } catch {
       // Ignore cross-origin errors (shouldn't happen with srcdoc)
     }
@@ -330,7 +355,12 @@ function HtmlContent({ html, viewport }: { html: string | undefined; viewport: s
       }
     }
     scheduleIframeResize()
-  }
+  }, [scheduleIframeResize])
+
+  const handleIframeLoad = useCallback(() => {
+    cleanupIframe()
+    setupIframe()
+  }, [cleanupIframe, setupIframe])
 
   if (!html) {
     return (


### PR DESCRIPTION
Follow-up fixes on top of #538, **verified in a real browser** (dev server + Chrome, tall / short / full-height-background emails across viewport switches), not just unit tests.

### 🔴 Viewport switch permanently broke the preview
The effect that tore down the ResizeObserver/listeners was keyed on `viewport`, but changing the viewport only mutates the iframe's `style`/`className` — it does **not** change `srcDoc`, so the iframe never reloads and `onLoad` never re-fires to re-attach them. Verified on the tall email: after one switch the iframe height sticks at `100%` (clipped to ~610px with 4366px of content; footer unreachable), and in-iframe keyboard shortcuts stop forwarding.

**Fix:** split the effect — `html` change still resets (iframe reloads → `onLoad` re-attaches), while `viewport` change re-measures in place with the listeners left intact. Verified: after switching viewport the iframe tracks content height again, and keyboard forwarding still works.

### 🟢 `documentElement.clientHeight` removed from the height calc
For the root element it returns the iframe's own viewport height, so including it in `Math.max` is conceptually wrong for a content-height measurement. Browser A/B shows removing it is neutral for full-height-background emails (identical to `main`); it's a correctness cleanup, not a user-visible change.

### 🟢 `fonts.ready` callback made cancelable
Gated behind a disposed flag tied to cleanup so a late webfont load can't resize a torn-down/replaced iframe.

### Known limitation (unchanged from #538)
Switching from a narrow (tall) viewport back to a wide (short) one doesn't shrink the iframe back down — the browser's `scrollHeight` pins to the current iframe height, so it keeps extra whitespace. This is **not** a regression (nothing is clipped, the footer stays reachable, and `main` is worse here), just not yet improved. A proper shrink-to-fit needs a measure-after-collapse pass and is left for a follow-up.

Typecheck + full `@maildev/ui` suite pass.