### PR TITLE
Fix Docker build on pnpm 10 (injected workspace deploy)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The root `package.json` is `private` (legacy v2 code) and is **not** published.
 ## Prerequisites
 
 - Node.js `>=20`
-- [pnpm](https://pnpm.io) `9.15.4` (pinned via `packageManager`)
+- [pnpm](https://pnpm.io) `10.34.4` (pinned via `packageManager`)
 
 ## Development
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,15 @@ RUN pnpm install --frozen-lockfile
 # Build every package (tsc for core/smtp/api/mcp/cli, Vite for the UI), then
 # `pnpm deploy` the CLI package + its @maildev/* workspace deps into an isolated,
 # production-only tree at /prod (no dev deps, no source, no other packages).
+# On pnpm 10 `pnpm deploy` requires injected workspace packages, otherwise it
+# errors with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE. We enable injection for
+# just this command (not globally in .npmrc) so the deployed tree gets real,
+# hard-copied @maildev/* deps while normal `pnpm install`/`pnpm dev` keep using
+# symlinks for live cross-package rebuilds.
 FROM deps AS build
 WORKDIR /workspace
 RUN pnpm build
-RUN pnpm --filter=maildev deploy --prod /prod
+RUN pnpm --filter=maildev deploy --prod --config.inject-workspace-packages=true /prod
 
 # ── Production ───────────────────────────────────────────────────────────────
 FROM base AS prod


### PR DESCRIPTION
## Problem

The Docker image can't build from `main`. The build stage runs:

```dockerfile
RUN pnpm --filter=maildev deploy --prod /prod
```

On pnpm 10 (repo is pinned to `pnpm@10.34.4`) this fails:

```
ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE  By default, starting from pnpm v10, we only
deploy from workspaces that have "inject-workspace-packages=true" set
```

The pre-v10 `pnpm deploy` built the isolated tree from *symlinked* workspace deps, which could diverge from a real install. pnpm 10 now requires **injected** (hard-copied) workspace packages so the deployed tree is deterministic.

## Fix

Enable injection **for just the deploy command**, not globally:

```dockerfile
RUN pnpm --filter=maildev deploy --prod --config.inject-workspace-packages=true /prod
```

This uses pnpm's sanctioned mechanism (not the deprecated `--legacy` escape hatch, which pnpm has signaled may be removed). Scoping it to the one command matters: setting `inject-workspace-packages=true` globally in `.npmrc` would hard-copy `@maildev/*` into each package's `node_modules` during normal installs, breaking the `tsc --watch` live cross-package rebuilds that `pnpm dev` relies on.

### Verified locally
- Deploy succeeds without `--legacy`; produces a self-contained `/prod` with real injected `@maildev/*` deps (`dist/` present), and `node dist/bin/maildev.js --version` → `3.0.0-rc.1`.
- The repo's dev symlinks are untouched (`packages/cli/node_modules/@maildev/api` stays `-> ../../../api`), so `pnpm dev` live-reload keeps working.
- No `.npmrc` / `package.json` / lockfile changes.

Also bumps the pnpm version in `CONTRIBUTING.md` (`9.15.4` → `10.34.4`) to match `packageManager`.

Extracted as a standalone fix from #546 so this build-blocker can land independently of the HTTPS work.