### PR TITLE
Serve the web UI/API over HTTPS (supersedes #546)

### DIFF
--- a/.changeset/https-web-server.md
+++ b/.changeset/https-web-server.md
@@ -1,0 +1,11 @@
+---
+'@maildev/api': patch
+'maildev': patch
+---
+
+Serve the web UI / REST API over HTTPS when `--https` (with `--https-cert` and
+`--https-key`) is set. The Fastify server now actually honors these options —
+previously the flags existed but the web server always served plain HTTP. HTTPS
+can also be configured via `MAILDEV_HTTPS`, `MAILDEV_HTTPS_CERT`, and
+`MAILDEV_HTTPS_KEY`, and the Docker healthcheck detects `MAILDEV_HTTPS` and
+probes over HTTPS so TLS-enabled containers report healthy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,5 @@ ENV MAILDEV_SMTP_PORT=1025
 
 ENTRYPOINT ["node", "dist/bin/maildev.js"]
 
-HEALTHCHECK --interval=10s --timeout=5s \
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
   CMD ["node", "dist/bin/healthcheck.js"]

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -4,9 +4,15 @@
  * REST API and WebSocket server for MailDev.
  */
 
-import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify'
+import Fastify, {
+  type FastifyInstance,
+  type FastifyServerOptions,
+  type FastifyRequest,
+  type FastifyReply,
+} from 'fastify'
 import cors from '@fastify/cors'
 import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 import { EventEmitter } from 'node:events'
 import { Server as SocketServer } from 'socket.io'
 import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js'
@@ -48,10 +54,31 @@ export class APIServer extends EventEmitter {
     this.smtp = options.smtp
     this.options = options
 
-    // Create Fastify instance
-    this.app = Fastify({
+    // Create Fastify instance, serving over HTTPS when configured. Typed as a
+    // plain record because Fastify's overloaded call signature collapses
+    // `Parameters<typeof Fastify>[0]` to `never`.
+    const fastifyOptions: Record<string, unknown> = {
       logger: options.logger ?? false,
-    })
+    }
+
+    if (options.https) {
+      if (!options.httpsCert || !options.httpsKey) {
+        throw new Error('HTTPS is enabled but httpsCert and httpsKey were not provided')
+      }
+      try {
+        fastifyOptions.https = {
+          cert: readFileSync(options.httpsCert),
+          key: readFileSync(options.httpsKey),
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        throw new Error(`Failed to read HTTPS certificate/key files: ${message}`)
+      }
+    }
+
+    // Fastify's instance type differs for HTTPS; we hold it as the common
+    // FastifyInstance either way.
+    this.app = Fastify(fastifyOptions as unknown as FastifyServerOptions) as unknown as FastifyInstance
   }
 
   /**
@@ -93,7 +120,8 @@ export class APIServer extends EventEmitter {
     await this.app.listen({ port, host })
 
     const printHost = host === '0.0.0.0' ? 'localhost' : host
-    console.info(`MailDev API running at http://${printHost}:${port}${this.options.basePath ?? ''}`)
+    const protocol = this.options.https ? 'https' : 'http'
+    console.info(`MailDev API running at ${protocol}://${printHost}:${port}${this.options.basePath ?? ''}`)
 
     this.emit('listening', { port, host })
   }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -15,6 +15,12 @@ export interface APIServerOptions {
   host?: string
   /** Base path for all routes (default: '/') */
   basePath?: string
+  /** Serve the API/UI over HTTPS (requires httpsCert and httpsKey) */
+  https?: boolean
+  /** Path to the HTTPS certificate file (PEM) */
+  httpsCert?: string
+  /** Path to the HTTPS private key file (PEM) */
+  httpsKey?: string
   /** Storage backend for emails */
   storage: Storage
   /** SMTP server instance for events (optional) */

--- a/packages/cli/src/__tests__/bin/healthcheck.test.ts
+++ b/packages/cli/src/__tests__/bin/healthcheck.test.ts
@@ -1,7 +1,56 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import net from 'node:net'
 import http from 'node:http'
+import https from 'node:https'
 import { normalizeBasePath, resolveHealthcheck, runHealthcheck } from '../../bin/healthcheck.js'
+
+// Self-signed cert/key (CN=localhost, SAN 127.0.0.1) used only to exercise the
+// HTTPS probe path. runHealthcheck must accept it despite it being self-signed.
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIICyzCCAbOgAwIBAgIJAO2mr+hKyLhqMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAgFw0yNjA4MTMxNTMwMjlaGA8yMTI2MDcyMDE1MzAyOVow
+FDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAs2H0jSOISExuEhhDPmPZ6LdBydA+aPEAYu43ZQ05urkk36o7v74dYRQ7
+yDo19mZ+jWLiIU3vtNSu32SlCLY8JJnkZmr0PLLCgLzo4Vy+HCQMQtaOnIP1mxQq
+wKgGDSZUkpBM2kl2cLrE39mY8B1ezxgTU0Kx/PSdTVAragLJvEaUmo504WhuCV0q
+FmVRbcUV8a5r/XuJRCDEmWmx8+nQC1JErUGigfkiMzP+g6mHjbpqgHAS27Zk5Fii
+M27FHW8Wyrt7iuWp+xZOHLPPEee+EPc+Su80eV/A8y44NHHshK11zedZCUYjA7A9
+H7R76FdgCY8qJ7Tl4qeiFhME2bN/UQIDAQABox4wHDAaBgNVHREEEzARgglsb2Nh
+bGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAEurRUiZiSgkmw46Q5mgVX3Y
+VIDou4xi/rl8WFgeqQmXQcZLnCOrKe9/BwCED22fzRkmgT6YWgenXUI21iKsHHOy
+RagC95ZcQXMjUN1viDgGMJULJn7WrBQ6nPmV7uDz6rlqrC2c+OaLTaPOBlkEMui3
+nbWzLu89eFOpXH1g+DSea8kUXUTCUvVOjcwPP7OgVQItI5ZYWsEKSihT+yhv8ujO
+gidGrRsC0bSpUdXqOsnQjA5VNPIIYsrUys38mjwCVhppWkMS6LB8mArEadg+u4UR
+8b1dl3UG21pgU/qf5FynB79g9WOWKdxriybyGUHEfC63PtuR5eFH6tjBEKvINCQ=
+-----END CERTIFICATE-----`
+const TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCzYfSNI4hITG4S
+GEM+Y9not0HJ0D5o8QBi7jdlDTm6uSTfqju/vh1hFDvIOjX2Zn6NYuIhTe+01K7f
+ZKUItjwkmeRmavQ8ssKAvOjhXL4cJAxC1o6cg/WbFCrAqAYNJlSSkEzaSXZwusTf
+2ZjwHV7PGBNTQrH89J1NUCtqAsm8RpSajnThaG4JXSoWZVFtxRXxrmv9e4lEIMSZ
+abHz6dALUkStQaKB+SIzM/6DqYeNumqAcBLbtmTkWKIzbsUdbxbKu3uK5an7Fk4c
+s88R574Q9z5K7zR5X8DzLjg0ceyErXXN51kJRiMDsD0ftHvoV2AJjyontOXip6IW
+EwTZs39RAgMBAAECggEAWDQlTLUZEPvL78fQYMA2aPCbP8HOvkkquHqL8HtVVJQv
+Jm+NW5X+2jpZvvWojRUOyzTBHkE1ScR+jEfvwl3hKtok7ZtPpvz7GNRK6m1w6WNs
+R/06OInGXc/Hyd2UxCiB02Ny9q7Ct2GO5scXJZI7iTc8YWddH5WkN1zhTAo86f8z
+bH3ImMBZQLeDQGzyMTGOOhlCAWgbRbnUPGpOXnmV24V/6/nNZ4iiNYC4bAPnmJfa
+FaFZNxLJwfT7G5k+i1MKPyYDmpTz7ToNdX98u6ALhtsa3D5P1oFwnnvfHv8FOlDo
+yaIcuSL4IdL4Js0El/hJR1feGdgID/ChBix1Kvc8AQKBgQDkbxAPLLCrwFKaqExK
+lJxRVQI8KwN6RlOyXiFD/dmtIIRmIMoKixnNe557A0ZGb6Se6ksTkhwyXT2kxw9s
+mOIjW/J3Tqf6q0IpNMK6EDdSpR91JyPg1/zi5oGjz+QD35Ct3nr8YJiyNdms2uXk
+w/VNTCmlW57dSZKF1o6tc4uRwQKBgQDJB5GU6emHaSdBOHEC2/UkxUmDBBA5JPT5
+lj87X+c4ru0kU4aW0VYEufnNFxfsU2MDz7JG7rCFkeVJedfJKUSLH+noQl6RzEQS
+WiGaYUJJ6+3jeM2bIxiQmD+zS+sdmRNyIFH+FPdwLZiVYvo9hjtoNrv2n4jFhptZ
+yv8TYMAxkQKBgQChjJoC4UwgaucAUT2DEQ5rxn7KJnFTLCFM550HBKPI+FIqF85L
+Hoyk8WPnAy3T6mi1qmRl9tLSG3bY7Z5O4uAquYAEODA76pnjoliEVauKWxSgOYn6
+HUXPAc11GDTdOGKNU+YOThIvFj5XLIeg/aShgdeCBgWX4cwpss88g5aVAQKBgQDF
+1uYGKIIEGo9gV1yY1MGYE3S6NJiGtIFG0/+cvlA+76BAPNdau9+svR5DIXQQxyvN
+x2yK9ELS4PdG7VtZBH0JcjnvssmBMQbZDMy/MvJa745pbCzkfZCiVMNz/8X+lfSW
+P4qRxC6TvrvIYOUnAWCbuioXl3+x7TwcDXQkrPXYkQKBgQDZfwlUVqCbZ/nYtp0R
+4lT89ClPa4clcrk/JDbnJA2/dwVh8kLh+Pzwlrwzpk3RHbXG/nFkoHkJvohSaY1A
+CcooVDXRBK3rhxSde+AtWkBoKLUKqYVhLsrTG7ys+u90SgBcCkih1LqIxj743GrK
+lXmoSjQVGK2M07xW7Bh7PbgK+Q==
+-----END PRIVATE KEY-----`
 
 describe('normalizeBasePath', () => {
   it('treats empty / root as no prefix', () => {
@@ -28,6 +77,7 @@ describe('resolveHealthcheck', () => {
       host: '127.0.0.1',
       port: 1080,
       path: '/api/healthz',
+      secure: false,
     })
   })
 
@@ -37,7 +87,13 @@ describe('resolveHealthcheck', () => {
       host: '127.0.0.1',
       port: 8080,
       path: '/mail/api/healthz',
+      secure: false,
     })
+  })
+
+  it('probes over HTTPS when MAILDEV_HTTPS is set', () => {
+    expect(resolveHealthcheck({ MAILDEV_HTTPS: 'true' })).toMatchObject({ mode: 'web', secure: true })
+    expect(resolveHealthcheck({ MAILDEV_HTTPS: '1' }).secure).toBe(true)
   })
 
   it('probes the SMTP port when the web UI is disabled', () => {
@@ -80,6 +136,21 @@ describe('runHealthcheck (integration)', () => {
   it('returns false when the web endpoint is not reachable', async () => {
     // Nothing listening on this port.
     expect(await runHealthcheck({ MAILDEV_WEB_PORT: '1' })).toBe(false)
+  })
+
+  it('returns true probing an HTTPS endpoint with a self-signed cert', async () => {
+    const server = https.createServer({ cert: TEST_CERT, key: TEST_KEY }, (req, res) => {
+      res.statusCode = req.url === '/api/healthz' ? 200 : 404
+      res.end()
+    })
+    const port = await listen(server)
+    expect(await runHealthcheck({ MAILDEV_WEB_PORT: String(port), MAILDEV_HTTPS: 'true' })).toBe(true)
+  })
+
+  it('returns false when probing HTTPS but the server only speaks HTTP', async () => {
+    const server = http.createServer((_req, res) => res.end())
+    const port = await listen(server)
+    expect(await runHealthcheck({ MAILDEV_WEB_PORT: String(port), MAILDEV_HTTPS: 'true' })).toBe(false)
   })
 
   it('returns true when the SMTP port accepts a connection (web disabled)', async () => {

--- a/packages/cli/src/bin/healthcheck.ts
+++ b/packages/cli/src/bin/healthcheck.ts
@@ -6,7 +6,7 @@
  * MAILDEV_* environment variables the server uses and probes the endpoint that
  * is actually listening:
  *
- *   - Web UI enabled  -> HTTP GET http://127.0.0.1:<web><basePath>/api/healthz
+ *   - Web UI enabled  -> HTTP(S) GET http(s)://127.0.0.1:<web><basePath>/api/healthz
  *   - Web UI disabled -> TCP connect to 127.0.0.1:<smtp>
  *
  * Design notes (each addresses a reported bug):
@@ -16,10 +16,14 @@
  *     `--disable-web` containers still report healthy. (#544)
  *   - Normalizes the base path so a trailing slash can't produce a `//` in the
  *     probe URL. (#542)
+ *   - Probes over HTTPS (ignoring the self-signed cert) when MAILDEV_HTTPS is
+ *     set, so TLS-enabled containers don't report unhealthy. The env var is the
+ *     same one that turns HTTPS on, so the probe always matches the server.
  */
 
 import net from 'node:net'
 import http from 'node:http'
+import https from 'node:https'
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_WEB_PORT = 1080
@@ -33,6 +37,8 @@ export interface HealthcheckPlan {
   port: number
   /** Request path for `web` mode. */
   path?: string
+  /** Use HTTPS (ignoring cert validation) for `web` mode. */
+  secure?: boolean
 }
 
 function parseBoolean(value: string | undefined): boolean {
@@ -71,19 +77,28 @@ export function resolveHealthcheck(env: NodeJS.ProcessEnv): HealthcheckPlan {
     host: HOST,
     port: parsePort(env.MAILDEV_WEB_PORT, DEFAULT_WEB_PORT),
     path: `${basePath}/api/healthz`,
+    secure: parseBoolean(env.MAILDEV_HTTPS),
   }
 }
 
 function checkWeb(plan: HealthcheckPlan): Promise<boolean> {
   return new Promise((resolve) => {
-    const req = http.request(
-      { host: plan.host, port: plan.port, path: plan.path, method: 'GET', timeout: TIMEOUT_MS },
-      (res) => {
-        res.resume() // drain
-        const status = res.statusCode ?? 0
-        resolve(status >= 200 && status < 300)
-      }
-    )
+    // Ignore certificate validation: MailDev's HTTPS mode typically uses a
+    // self-signed cert, and this is a loopback liveness probe.
+    const transport = plan.secure ? https : http
+    const options = {
+      host: plan.host,
+      port: plan.port,
+      path: plan.path,
+      method: 'GET',
+      timeout: TIMEOUT_MS,
+      ...(plan.secure ? { rejectUnauthorized: false } : {}),
+    }
+    const req = transport.request(options, (res) => {
+      res.resume() // drain
+      const status = res.statusCode ?? 0
+      resolve(status >= 200 && status < 300)
+    })
     req.on('error', () => resolve(false))
     req.on('timeout', () => {
       req.destroy()

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -23,6 +23,9 @@ const ENV_MAPPING: Record<string, keyof PartialMailDevConfig> = {
   MAILDEV_WEB_USER: 'webUser',
   MAILDEV_WEB_PASS: 'webPass',
   MAILDEV_BASE_PATHNAME: 'basePathname',
+  MAILDEV_HTTPS: 'https',
+  MAILDEV_HTTPS_CERT: 'httpsCert',
+  MAILDEV_HTTPS_KEY: 'httpsKey',
 
   // Outgoing/Relay
   MAILDEV_OUTGOING_HOST: 'outgoingHost',

--- a/packages/cli/src/server/orchestrator.ts
+++ b/packages/cli/src/server/orchestrator.ts
@@ -143,6 +143,15 @@ export class Orchestrator {
       if (this.config.verbose !== undefined) {
         apiOptions.logger = this.config.verbose
       }
+      if (this.config.https) {
+        apiOptions.https = true
+        if (this.config.httpsCert) {
+          apiOptions.httpsCert = this.config.httpsCert
+        }
+        if (this.config.httpsKey) {
+          apiOptions.httpsKey = this.config.httpsKey
+        }
+      }
       if (this.config.mcp) {
         apiOptions.mcp = { enabled: true }
       }


### PR DESCRIPTION
Reworks #546 to actually serve HTTPS from the Fastify web server, composed with the `dist/bin/healthcheck.js` from #550 rather than reverting to a shell `curl` healthcheck.

## What was broken

The `--https` / `--https-cert` / `--https-key` flags, config fields, and validation already existed on `main`, but the API server **never used them** — it always constructed a plain-HTTP Fastify instance. So `--https` silently had no effect.

## Changes

- **`@maildev/api`**: construct Fastify with the `https` option (reads cert/key) when `options.https` is set; throw if enabled without cert/key; log the `https://` URL. (`server.ts`, `types.ts`)
- **CLI orchestrator**: thread `https`/`httpsCert`/`httpsKey` config into the API options.
- **Env config**: map `MAILDEV_HTTPS` / `MAILDEV_HTTPS_CERT` / `MAILDEV_HTTPS_KEY` → config, so HTTPS can be enabled by env (the container path — previously impossible; `MAILDEV_HTTPS` was parsed but never applied).
- **Healthcheck** (`dist/bin/healthcheck.js`): when `MAILDEV_HTTPS` is set, probe over HTTPS with cert validation disabled (self-signed loopback). This closes the HTTPS gap noted in #550's review. Uses the same env var that turns HTTPS on, so the probe always matches the server.
- **Dockerfile**: keep the Node healthcheck CMD; add `--start-period=5s --retries=3` so a slow first boot isn't flagged unhealthy.

Deliberately **not** carried over from #546: the `/tmp/maildev-https` status-file IPC (unnecessary — the healthcheck reads the same env the server does) and the unrelated CLAUDE.md rewrite.

## Verification

Unit + integration tests (api 27, cli 105 incl. 12 healthcheck, 3 new for HTTPS). Plus end-to-end against the **built** CLI with a self-signed cert:

- `--https` → `MailDev API running at https://localhost:1080`; `curl -k https://.../api/healthz` → **200**; plain `http://` → connection reset.
- Email sent over SMTP reads back over HTTPS (`/api/email` → 3 emails).
- `MAILDEV_HTTPS=true node dist/bin/healthcheck.js` → exit **0**; HTTP probe against the HTTPS server → exit **1**.
- HTTPS enabled purely via `MAILDEV_HTTPS*` env vars → serves HTTPS (container path).
- `--https` without cert/key → validation error, exit 1.

Closes #546 (superseded).