### PR TITLE
perf(core): back MemoryStorage with an insertion-ordered Map (1/3)

### DIFF
--- a/.changeset/map-backed-storage.md
+++ b/.changeset/map-backed-storage.md
@@ -1,0 +1,17 @@
+---
+'@maildev/core': patch
+'@maildev/api': patch
+'@maildev/smtp': patch
+---
+
+Make in-memory storage O(1) so large inboxes stay responsive
+
+The array-backed store made ingest and mark-all-read quadratic, so a large
+inbox became slow to fill and slow to clear. `MemoryStorage` is now backed by an
+insertion-ordered `Map`, making `getById`, `save` and `delete` O(1), with the
+unread count maintained incrementally so `stats()` never has to scan.
+
+Breaking change:
+
+- `@maildev/core`: `Storage` implementations must now provide `markAllRead` and
+  `stats`. A new `StorageStats` type is exported.

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -295,21 +295,7 @@ export class APIServer extends EventEmitter {
     // Mark all emails as read
     this.app.patch(`${apiPath}/email/read-all`, async (_request, reply) => {
       try {
-        if (this.smtp) {
-          const count = await this.smtp.markAllRead()
-          return count
-        } else {
-          const emails = await this.storage.getAll()
-          let count = 0
-          for (const email of emails) {
-            if (!email.read) {
-              email.read = true
-              await this.storage.save(email)
-              count++
-            }
-          }
-          return count
-        }
+        return this.smtp ? await this.smtp.markAllRead() : await this.storage.markAllRead()
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
         return reply.status(500).send({ error: message })

--- a/packages/core/src/__tests__/storage-scale.test.ts
+++ b/packages/core/src/__tests__/storage-scale.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Guardrails against the regressions that made MailDev unusable with a large
+ * inbox.
+ *
+ * Budgets sit roughly 10x above what the current implementation needs and well
+ * below what the previous array-backed store took, so they trip on an
+ * algorithmic regression (a per-operation O(n) scan reappearing) rather than on
+ * a slow machine. Reference timings at 20,000 emails:
+ *
+ *   operation      before    after
+ *   save all       ~1070ms     41ms
+ *   getById x2000   ~180ms    0.6ms
+ *   markAllRead    >1000ms    0.6ms
+ */
+import { describe, it, expect } from 'vitest'
+import { MemoryStorage } from '../storage/memory.js'
+import type { Email } from '../types/index.js'
+
+/** Emails used for the scale checks */
+const COUNT = 20_000
+
+const createTestEmail = (index: number): Email => ({
+  id: `email-${index}`,
+  time: new Date(Date.UTC(2026, 0, 1) + index * 1000),
+  read: false,
+  subject: `Test message ${index}`,
+  source: `/tmp/email-${index}.eml`,
+  size: 1024,
+  sizeHuman: '1 KB',
+  from: [{ address: `sender${index % 50}@example.com` }],
+  to: [{ address: 'recipient@example.com' }],
+  headers: {},
+  attachments: [],
+  envelope: {
+    from: { address: `sender${index % 50}@example.com` },
+    to: [{ address: 'recipient@example.com' }],
+  },
+  text: `Body of message ${index}`,
+})
+
+/** Populate a store with COUNT emails, returning how long it took */
+async function fill(storage: MemoryStorage): Promise<number> {
+  const started = performance.now()
+  for (let i = 0; i < COUNT; i++) {
+    await storage.save(createTestEmail(i))
+  }
+  return performance.now() - started
+}
+
+/** Time an async operation in milliseconds */
+async function timed(operation: () => Promise<unknown>): Promise<number> {
+  const started = performance.now()
+  await operation()
+  return performance.now() - started
+}
+
+describe('MemoryStorage at scale', () => {
+  it(`should ingest ${COUNT} emails without degrading`, async () => {
+    const storage = new MemoryStorage()
+
+    // Was quadratic: every save scanned the array to look for an existing id.
+    expect(await fill(storage)).toBeLessThan(400)
+    expect(await storage.count()).toBe(COUNT)
+  })
+
+  it('should look emails up by id in constant time', async () => {
+    const storage = new MemoryStorage()
+    await fill(storage)
+
+    const elapsed = await timed(async () => {
+      for (let i = 0; i < 2000; i++) {
+        // Spread across the store so a linear scan can't get lucky
+        await storage.getById(`email-${(i * 7919) % COUNT}`)
+      }
+    })
+
+    expect(elapsed).toBeLessThan(100)
+  })
+
+  it('should mark everything read in a single pass', async () => {
+    const storage = new MemoryStorage()
+    await fill(storage)
+
+    // Was quadratic: getAll() followed by a save() per unread email.
+    const elapsed = await timed(() => storage.markAllRead())
+
+    expect(elapsed).toBeLessThan(200)
+    expect((await storage.stats()).unread).toBe(0)
+  })
+
+  it('should report stats without scanning', async () => {
+    const storage = new MemoryStorage()
+    await fill(storage)
+
+    const elapsed = await timed(() => storage.stats())
+
+    expect(elapsed).toBeLessThan(20)
+    expect(await storage.stats()).toEqual({ total: COUNT, unread: COUNT })
+  })
+
+  it('should stay within maxEmails while ingesting far more', async () => {
+    const storage = new MemoryStorage({ maxEmails: 1000 })
+
+    const elapsed = await fill(storage)
+
+    expect(elapsed).toBeLessThan(400)
+    expect(await storage.count()).toBe(1000)
+    // The newest survive, the oldest are gone
+    expect(await storage.getById(`email-${COUNT - 1}`)).toBeDefined()
+    expect(await storage.getById('email-0')).toBeUndefined()
+  })
+})

--- a/packages/core/src/__tests__/storage.test.ts
+++ b/packages/core/src/__tests__/storage.test.ts
@@ -101,6 +101,74 @@ describe('MemoryStorage', () => {
       expect(emails.find((e) => e.id === '1')).toBeUndefined()
       expect(emails.find((e) => e.id === '4')).toBeDefined()
     })
+
+    it('should keep an updated email in its original position', async () => {
+      const limitedStorage = new MemoryStorage({ maxEmails: 2 })
+
+      await limitedStorage.save(createTestEmail('1'))
+      await limitedStorage.save(createTestEmail('2'))
+      // Touching the oldest email must not make it look newest
+      await limitedStorage.save(createTestEmail('1', { read: true }))
+      await limitedStorage.save(createTestEmail('3'))
+
+      const emails = await limitedStorage.getAll()
+      expect(emails.map((e) => e.id)).toEqual(['2', '3'])
+    })
+  })
+
+  describe('markAllRead', () => {
+    it('should return 0 when everything is already read', async () => {
+      await storage.save(createTestEmail('1', { read: true }))
+      expect(await storage.markAllRead()).toBe(0)
+    })
+
+    it('should mark unread emails as read and return the count', async () => {
+      await storage.save(createTestEmail('1'))
+      await storage.save(createTestEmail('2', { read: true }))
+      await storage.save(createTestEmail('3'))
+
+      expect(await storage.markAllRead()).toBe(2)
+
+      const emails = await storage.getAll()
+      expect(emails.every((e) => e.read)).toBe(true)
+      expect((await storage.stats()).unread).toBe(0)
+    })
+  })
+
+  describe('stats', () => {
+    it('should report zero for an empty store', async () => {
+      expect(await storage.stats()).toEqual({ total: 0, unread: 0 })
+    })
+
+    it('should track unread across save, update and delete', async () => {
+      await storage.save(createTestEmail('1'))
+      await storage.save(createTestEmail('2'))
+      expect(await storage.stats()).toEqual({ total: 2, unread: 2 })
+
+      // Reading one
+      await storage.save(createTestEmail('1', { read: true }))
+      expect(await storage.stats()).toEqual({ total: 2, unread: 1 })
+
+      // Marking it unread again
+      await storage.save(createTestEmail('1', { read: false }))
+      expect(await storage.stats()).toEqual({ total: 2, unread: 2 })
+
+      await storage.delete('1')
+      expect(await storage.stats()).toEqual({ total: 1, unread: 1 })
+
+      await storage.deleteAll()
+      expect(await storage.stats()).toEqual({ total: 0, unread: 0 })
+    })
+
+    it('should keep the unread count correct when emails are evicted', async () => {
+      const limitedStorage = new MemoryStorage({ maxEmails: 2 })
+
+      await limitedStorage.save(createTestEmail('1'))
+      await limitedStorage.save(createTestEmail('2'))
+      await limitedStorage.save(createTestEmail('3'))
+
+      expect(await limitedStorage.stats()).toEqual({ total: 2, unread: 2 })
+    })
   })
 
   describe('delete', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export type {
   StorageOptions,
   Storage,
   StorageEvents,
+  StorageStats,
 } from './types/index.js'
 
 // Storage implementations

--- a/packages/core/src/storage/memory.ts
+++ b/packages/core/src/storage/memory.ts
@@ -1,15 +1,31 @@
-import type { Email, Storage, StorageOptions, StorageQuery } from '../types/index.js'
+import { EventEmitter } from 'node:events'
+import type {
+  Email,
+  Storage,
+  StorageOptions,
+  StorageQuery,
+  StorageStats,
+} from '../types/index.js'
 import { filterEmails } from '../utils/filter.js'
 
 /**
  * In-memory storage implementation
- * Stores emails in a simple array with no persistence
+ *
+ * Emails are held in an insertion-ordered Map, so lookup, save and delete are
+ * all O(1) and the oldest email is always the first entry — which is what makes
+ * `maxEmails` eviction cheap.
+ *
+ * Emits `add`, `delete` and `clear`.
  */
-export class MemoryStorage implements Storage {
+export class MemoryStorage extends EventEmitter implements Storage {
   readonly options: StorageOptions
-  protected emails: Email[] = []
+  /** Insertion-ordered, so the first entry is always the oldest email */
+  protected emails = new Map<string, Email>()
+  /** Kept in sync on every mutation so `stats()` never has to scan */
+  private unreadCount = 0
 
   constructor(options: StorageOptions = {}) {
+    super()
     this.options = {
       maxEmails: 0,
       ...options,
@@ -18,16 +34,18 @@ export class MemoryStorage implements Storage {
 
   /**
    * Get all emails in the store
+   *
+   * Materialises the entire store; use sparingly for anything that faces a user.
    */
   async getAll(): Promise<Email[]> {
-    return [...this.emails]
+    return [...this.emails.values()]
   }
 
   /**
    * Get a single email by ID
    */
   async getById(id: string): Promise<Email | undefined> {
-    return this.emails.find((email) => email.id === id)
+    return this.emails.get(id)
   }
 
   /**
@@ -35,19 +53,35 @@ export class MemoryStorage implements Storage {
    * If maxEmails is set and exceeded, removes oldest emails
    */
   async save(email: Email): Promise<void> {
-    // Check if email with this ID already exists
-    const existingIndex = this.emails.findIndex((e) => e.id === email.id)
-    if (existingIndex >= 0) {
-      // Update existing email
-      this.emails[existingIndex] = email
-    } else {
-      // Add new email
-      this.emails.push(email)
+    const existing = this.emails.get(email.id)
 
-      // Enforce maxEmails limit
-      if (this.options.maxEmails && this.options.maxEmails > 0) {
-        while (this.emails.length > this.options.maxEmails) {
-          this.emails.shift() // Remove oldest
+    if (existing) {
+      // Re-setting an existing key keeps its position, so updates (marking an
+      // email read, say) never disturb the arrival ordering.
+      if (existing.read !== email.read) {
+        this.unreadCount += email.read ? -1 : 1
+      }
+      this.emails.set(email.id, email)
+      return
+    }
+
+    this.emails.set(email.id, email)
+    if (!email.read) {
+      this.unreadCount++
+    }
+    this.emit('add', email)
+
+    // Enforce maxEmails by dropping the oldest entries. Iteration order is
+    // insertion order, so the first entries walked are the oldest.
+    const max = this.options.maxEmails ?? 0
+    if (max > 0) {
+      for (const [id, oldest] of this.emails) {
+        if (this.emails.size <= max) {
+          break
+        }
+        this.emails.delete(id)
+        if (!oldest.read) {
+          this.unreadCount--
         }
       }
     }
@@ -57,20 +91,48 @@ export class MemoryStorage implements Storage {
    * Delete an email by ID
    */
   async delete(id: string): Promise<boolean> {
-    const index = this.emails.findIndex((email) => email.id === id)
-    if (index >= 0) {
-      this.emails.splice(index, 1)
-      return true
+    const email = this.emails.get(id)
+    if (!email) {
+      return false
     }
-    return false
+
+    this.emails.delete(id)
+    if (!email.read) {
+      this.unreadCount--
+    }
+    this.emit('delete', id)
+
+    return true
   }
 
   /**
    * Delete all emails from the store
    */
   async deleteAll(): Promise<number> {
-    const count = this.emails.length
-    this.emails = []
+    const count = this.emails.size
+    this.emails.clear()
+    this.unreadCount = 0
+    this.emit('clear')
+    return count
+  }
+
+  /**
+   * Mark every unread email as read in a single pass
+   */
+  async markAllRead(): Promise<number> {
+    if (this.unreadCount === 0) {
+      return 0
+    }
+
+    let count = 0
+    for (const email of this.emails.values()) {
+      if (!email.read) {
+        email.read = true
+        count++
+      }
+    }
+    this.unreadCount = 0
+
     return count
   }
 
@@ -78,14 +140,21 @@ export class MemoryStorage implements Storage {
    * Filter emails by query criteria
    */
   async filter(query: StorageQuery): Promise<Email[]> {
-    return filterEmails(this.emails, query)
+    return filterEmails([...this.emails.values()], query)
   }
 
   /**
    * Get the total count of emails
    */
   async count(): Promise<number> {
-    return this.emails.length
+    return this.emails.size
+  }
+
+  /**
+   * Get total and unread counts without loading any emails
+   */
+  async stats(): Promise<StorageStats> {
+    return { total: this.emails.size, unread: this.unreadCount }
   }
 
   /**
@@ -99,6 +168,7 @@ export class MemoryStorage implements Storage {
    * Close the storage (clears all emails)
    */
   async close(): Promise<void> {
-    this.emails = []
+    this.emails.clear()
+    this.unreadCount = 0
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,4 +15,5 @@ export type {
   StorageOptions,
   Storage,
   StorageEvents,
+  StorageStats,
 } from './storage.js'

--- a/packages/core/src/types/storage.ts
+++ b/packages/core/src/types/storage.ts
@@ -19,6 +19,16 @@ export interface StorageOptions {
 }
 
 /**
+ * Summary counts for the whole store
+ */
+export interface StorageStats {
+  /** Total emails held */
+  total: number
+  /** How many of them are unread */
+  unread: number
+}
+
+/**
  * Storage interface for email persistence
  * Implementations: MemoryStorage, FileStorage
  */
@@ -60,6 +70,12 @@ export interface Storage {
    */
   deleteAll(): Promise<number>
 
+  /**
+   * Mark every unread email as read in a single pass
+   * @returns Number of emails that changed from unread to read
+   */
+  markAllRead(): Promise<number>
+
   // Query Operations
 
   /**
@@ -74,6 +90,11 @@ export interface Storage {
    * @returns Number of stored emails
    */
   count(): Promise<number>
+
+  /**
+   * Get total and unread counts without loading any emails
+   */
+  stats(): Promise<StorageStats>
 
   // Lifecycle
 

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -222,18 +222,7 @@ export class SMTPServer extends EventEmitter {
    * Mark all emails as read
    */
   async markAllRead(): Promise<number> {
-    const emails = await this.storage.getAll()
-    let count = 0
-
-    for (const email of emails) {
-      if (!email.read) {
-        email.read = true
-        await this.storage.save(email)
-        count++
-      }
-    }
-
-    return count
+    return this.storage.markAllRead()
   }
 
   /**

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,0 +1,128 @@
+/**
+ * MailDev - bench.js -- measure how the API behaves with a large inbox
+ *
+ * Fills a MemoryStorage with a lot of realistic emails, then times the calls
+ * the web UI makes. Use it to check that a change hasn't reintroduced a
+ * per-request scan of the whole store, or a response that grows with it.
+ *
+ * Requires a build first:
+ *   pnpm build && node scripts/bench.js
+ *
+ * Options:
+ *   COUNT=10000   how many emails to load (default 10000)
+ *   BODY=12000    size of each message body in bytes (default 12000)
+ *   FULL=1        also time GET /api/email, which serialises the whole inbox.
+ *                 Off by default: past a few thousand emails it needs more heap
+ *                 than node is given and takes the process down with it, which
+ *                 is exactly the failure this work was about.
+ */
+
+const { MemoryStorage } = require('../packages/core/dist/index.js')
+const { createAPIServer } = require('../packages/api/dist/index.js')
+
+const COUNT = Number(process.env.COUNT ?? 10000)
+const BODY_SIZE = Number(process.env.BODY ?? 12000)
+
+const FILLER = 'Look at it! Once in a lifetime opportunity, man! '
+const REPEATS = Math.ceil(BODY_SIZE / FILLER.length)
+
+function makeEmail (index) {
+  // Built per email rather than shared, so heap numbers reflect what a real
+  // inbox of distinct messages actually costs
+  const body = `Message ${index}. ` + FILLER.repeat(REPEATS)
+
+  return {
+    id: `email-${index}`,
+    time: new Date(Date.now() - (COUNT - index) * 1000),
+    read: false,
+    subject: `Test message ${index}`,
+    source: `/tmp/email-${index}.eml`,
+    size: body.length,
+    sizeHuman: `${Math.round(body.length / 1024)} KB`,
+    from: [{ address: `sender${index % 50}@example.com`, name: `Sender ${index % 50}` }],
+    to: [{ address: 'johnny.utah@fbi.gov', name: 'Johnny Utah' }],
+    headers: { 'x-some-header': String(index) },
+    attachments: [],
+    envelope: {
+      from: { address: `sender${index % 50}@example.com` },
+      to: [{ address: 'johnny.utah@fbi.gov' }]
+    },
+    calculatedBcc: [],
+    html: `<!DOCTYPE html><html><body><p>${body}</p></body></html>`,
+    text: body
+  }
+}
+
+async function time (label, fn) {
+  const started = performance.now()
+  const result = await fn()
+  const elapsed = performance.now() - started
+  console.log(`  ${label.padEnd(44)} ${elapsed.toFixed(1).padStart(9)} ms`)
+  return result
+}
+
+function size (bytes) {
+  return bytes >= 1024 * 1024
+    ? `${(bytes / 1024 / 1024).toFixed(1)} MB`
+    : `${(bytes / 1024).toFixed(1)} KB`
+}
+
+function payload (bytes) {
+  console.log(`  ${''.padEnd(44)} ${size(bytes).padStart(12)}  payload`)
+}
+
+async function main () {
+  const storage = new MemoryStorage()
+  await storage.initialize()
+
+  console.log(`\nMailDev API benchmark - ${COUNT} emails, ~${BODY_SIZE} byte bodies\n`)
+
+  console.log('Storage')
+  await time(`save ${COUNT} emails`, async () => {
+    for (let i = 0; i < COUNT; i++) {
+      await storage.save(makeEmail(i))
+    }
+  })
+  await time('getById x1000 (spread across the store)', async () => {
+    for (let i = 0; i < 1000; i++) {
+      await storage.getById(`email-${(i * 7919) % COUNT}`)
+    }
+  })
+  await time('stats', () => storage.stats())
+
+  const server = createAPIServer({ storage, port: 0 })
+  await server.registerPlugins()
+
+  console.log('\nAPI')
+  const page = await time('GET /api/email/summary (list view)', () =>
+    server.server.inject({ method: 'GET', url: '/api/email/summary' })
+  )
+  payload(page.body.length)
+
+  const search = await time('GET /api/email/summary?search=...', () =>
+    server.server.inject({ method: 'GET', url: '/api/email/summary?search=message%209999' })
+  )
+  payload(search.body.length)
+
+  const readAll = await time('PATCH /api/email/read-all', () =>
+    server.server.inject({ method: 'PATCH', url: '/api/email/read-all' })
+  )
+  console.log(`  ${''.padEnd(44)} ${String(readAll.json()).padStart(12)}  marked read`)
+
+  if (process.env.FULL) {
+    const full = await time('GET /api/email (whole inbox, unpaginated)', () =>
+      server.server.inject({ method: 'GET', url: '/api/email' })
+    )
+    payload(full.body.length)
+  }
+
+  console.log(`\nheap used: ${size(process.memoryUsage().heapUsed)}\n`)
+
+  await server.stop()
+  await storage.close()
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Part 1 of 3 splitting the "responsive with large inboxes" work (originally #548) into focused, independently reviewable PRs.

## What
Backs `MemoryStorage` with an **insertion-ordered `Map`** instead of an array, so `getById`, `save` and `delete` are O(1) and the oldest email is always the first entry. The unread count is maintained incrementally, so `stats()` never scans.

Previously ingest and mark-all-read were quadratic — a large inbox was slow to fill and slow to clear.

## API surface
- Adds `markAllRead()` and `stats()` to the `Storage` interface, plus a `StorageStats` type.
- Routes the API and SMTP mark-all-read paths through the single-pass implementation.

## Breaking change
`Storage` implementations must now provide `markAllRead` and `stats`.

## Testing
`storage-scale.test.ts` guards against the O(n) regressions (ingest / getById / markAllRead / stats at 20k emails). Full suite, typecheck and lint pass.

---
Stack: **PR1 (this)** → PR2 (summary pagination) → PR3 (maxEmails eviction).
