### PR TITLE
feat: broadcast read state over websocket to keep tabs in sync

### DIFF
--- a/packages/api/src/__tests__/server.test.ts
+++ b/packages/api/src/__tests__/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { APIServer, createAPIServer } from '../server.js'
 import { MemoryStorage, type Email } from '@maildev/core'
 
@@ -176,6 +176,84 @@ describe('APIServer', () => {
       // Verify it was saved
       const saved = await storage.getById('test-789')
       expect(saved?.read).toBe(true)
+    })
+
+    it('should emit readMail over the socket only on the first open', async () => {
+      const testEmail: Email = {
+        id: 'socket-read',
+        time: new Date(),
+        read: false,
+        subject: 'Unread Email',
+        source: '/path/to/email.eml',
+        size: 512,
+        sizeHuman: '512 B',
+        from: [{ address: 'sender@test.com' }],
+        to: [{ address: 'recipient@test.com' }],
+        headers: {},
+        attachments: [],
+        envelope: {
+          from: { address: 'sender@test.com' },
+          to: [{ address: 'recipient@test.com' }],
+        },
+        calculatedBcc: [],
+      }
+      await storage.save(testEmail)
+
+      server = createAPIServer({ storage, port: 0 })
+      await server.start()
+
+      const emit = vi.fn()
+      // The socket only exists in SMTP mode; stand in a spy so the route's
+      // `this.io?.emit` is observable. `close` lets server.stop() tear it down.
+      ;(server as unknown as { io?: { emit: typeof emit; close: (cb: () => void) => void } }).io =
+        { emit, close: (cb) => cb() }
+
+      await server.server.inject({ method: 'GET', url: '/api/email/socket-read' })
+      expect(emit).toHaveBeenCalledWith('readMail', { id: 'socket-read' })
+
+      // Already read on the second open, so nothing is broadcast
+      emit.mockClear()
+      await server.server.inject({ method: 'GET', url: '/api/email/socket-read' })
+      expect(emit).not.toHaveBeenCalled()
+    })
+
+    it('should emit readAllMail only when read-all changed something', async () => {
+      const unread: Email = {
+        id: 'bulk-unread',
+        time: new Date(),
+        read: false,
+        subject: 'Unread',
+        source: '/path/to/email.eml',
+        size: 512,
+        sizeHuman: '512 B',
+        from: [{ address: 'sender@test.com' }],
+        to: [{ address: 'recipient@test.com' }],
+        headers: {},
+        attachments: [],
+        envelope: {
+          from: { address: 'sender@test.com' },
+          to: [{ address: 'recipient@test.com' }],
+        },
+        calculatedBcc: [],
+      }
+      await storage.save(unread)
+
+      server = createAPIServer({ storage, port: 0 })
+      await server.start()
+
+      const emit = vi.fn()
+      // The socket only exists in SMTP mode; stand in a spy so the route's
+      // `this.io?.emit` is observable. `close` lets server.stop() tear it down.
+      ;(server as unknown as { io?: { emit: typeof emit; close: (cb: () => void) => void } }).io =
+        { emit, close: (cb) => cb() }
+
+      await server.server.inject({ method: 'PATCH', url: '/api/email/read-all' })
+      expect(emit).toHaveBeenCalledWith('readAllMail')
+
+      // Everything is already read, so a second call changes nothing
+      emit.mockClear()
+      await server.server.inject({ method: 'PATCH', url: '/api/email/read-all' })
+      expect(emit).not.toHaveBeenCalled()
     })
 
     it('should return 404 for non-existent email', async () => {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -324,6 +324,9 @@ export class APIServer extends EventEmitter {
         if (!email.read) {
           email.read = true
           await this.storage.save(email)
+          // Let other tabs update their list and unread badge; the tab that
+          // opened the email has already done so optimistically.
+          this.io?.emit('readMail', { id })
         }
 
         return email
@@ -401,7 +404,15 @@ export class APIServer extends EventEmitter {
     // Mark all emails as read
     this.app.patch(`${apiPath}/email/read-all`, async (_request, reply) => {
       try {
-        return this.smtp ? await this.smtp.markAllRead() : await this.storage.markAllRead()
+        const count = this.smtp
+          ? await this.smtp.markAllRead()
+          : await this.storage.markAllRead()
+        // Only tabs other than the one that triggered it need telling, and only
+        // when something actually changed.
+        if (count > 0) {
+          this.io?.emit('readAllMail')
+        }
+        return count
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
         return reply.status(500).send({ error: message })

--- a/packages/ui/src/hooks/useEmails.ts
+++ b/packages/ui/src/hooks/useEmails.ts
@@ -72,7 +72,7 @@ export function useEmailList() {
  * server-wide unread count the badge reads from. Idempotent — an email that is
  * already read leaves the cache untouched, so re-opening never over-counts.
  */
-function markSummaryRead(queryClient: QueryClient, id: string) {
+export function markSummaryRead(queryClient: QueryClient, id: string) {
   queryClient.setQueriesData<InfiniteData<EmailSummaryPage>>(
     { queryKey: ['emails', 'summary'] },
     (data) => {

--- a/packages/ui/src/hooks/useSocket.ts
+++ b/packages/ui/src/hooks/useSocket.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { io, Socket } from 'socket.io-client'
 import type { EmailSummary } from '@maildev/core'
 import { useUIStore } from '../stores/ui'
+import { markSummaryRead } from './useEmails'
 import { getBasePath } from '../lib/basePath'
 
 // Notification debounce - max 1 notification per 2 seconds
@@ -119,6 +120,18 @@ export function useSocket() {
       scheduleRefresh()
       // Also invalidate the specific email query
       queryClient.invalidateQueries({ queryKey: ['email', data.id] })
+    })
+
+    // Another tab opened an email: flip it read in our list without a refetch.
+    // Idempotent, so the tab that opened it (already updated) is a no-op.
+    socket.on('readMail', (data: { id: string }) => {
+      markSummaryRead(queryClient, data.id)
+    })
+
+    // Another tab marked everything read: a coalesced refetch is the cheapest
+    // way to pull in the new read state and the zeroed unread count.
+    socket.on('readAllMail', () => {
+      scheduleRefresh()
     })
 
     return () => {


### PR DESCRIPTION
Marking an email read (opening it, or read-all) only updated the tab that did it. Emit readMail/readAllMail so other tabs update their list and unread badge. readMail reuses the optimistic summary cache patch and is idempotent, so the tab that opened the email is a no-op and no refetch is needed; read-all falls back to the existing coalesced refresh.