### PR TITLE
feat: dashboard routes and MCP deep links

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -52,6 +52,7 @@ flags or environment variables:
 | ---------------- | ------------------ | ----------------------- | --------------------------------- |
 | `-u, --url`      | `MAILDEV_API_URL`  | `http://localhost:1080` | MailDev REST API base URL         |
 | `-k, --api-key`  | `MAILDEV_API_KEY`  | _(none)_                | API key, if authentication is on  |
+| _(none)_         | `MAILDEV_WEB_URL`  | derived from API URL    | Web UI base URL for email deep links |
 
 ```bash
 MAILDEV_API_URL=http://localhost:1080 maildev-mcp
@@ -135,7 +136,14 @@ await maildev.start()
 
 ## Tools
 
-The MCP server exposes 5 tools:
+The MCP server exposes 5 tools.
+
+Email listings and details include a **deep link** to the message in the web UI
+(`URL: http://localhost:1080/#/email/<id>`), so a coding agent can hand back a
+clickable link to open the email. The link uses a hash route, so it keeps
+working under a reverse-proxy sub-path. Over the integrated HTTP transport the
+link points at the running server; for the standalone stdio server it is derived
+from `MAILDEV_API_URL` and can be overridden with `MAILDEV_WEB_URL`.
 
 ### `maildev_search_emails`
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -622,6 +622,20 @@ export class APIServer extends EventEmitter {
   /**
    * Setup MCP (Model Context Protocol) server for Claude integration
    */
+  /**
+   * Best-effort public base URL of the web UI (no trailing slash), derived
+   * from this server's own listen options. Used for MCP email deep links when
+   * no explicit URL is configured.
+   */
+  private defaultWebUrl(): string {
+    const host = this.options.host ?? DEFAULT_HOST
+    const printHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host
+    const port = this.options.port ?? DEFAULT_PORT
+    const protocol = this.options.https ? 'https' : 'http'
+    const basePath = this.options.basePath ?? ''
+    return `${protocol}://${printHost}:${port}${basePath}`
+  }
+
   private setupMCP(): void {
     if (!this.options.mcp?.enabled) {
       return
@@ -669,8 +683,11 @@ export class APIServer extends EventEmitter {
       { capabilities: { tools: {}, resources: {}, prompts: {} } }
     )
 
-    // Register handlers with direct storage access
-    registerMCPHandlers(this.mcpServer, dataSource)
+    // Register handlers with direct storage access. Deep links point at this
+    // server's own web UI unless an explicit public URL is configured (e.g.
+    // when reached through a reverse proxy).
+    const webUrl = this.options.mcp?.webUrl ?? this.defaultWebUrl()
+    registerMCPHandlers(this.mcpServer, dataSource, { webUrl })
 
     // Helper to get or create transport for a session
     const getOrCreateTransport = async (sessionId: string | undefined) => {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -41,6 +41,13 @@ export interface APIServerOptions {
 export interface MCPConfig {
   /** Enable MCP server at /mcp endpoint */
   enabled: boolean
+  /**
+   * Public base URL of the web UI (no trailing slash), used to build
+   * deep links to emails in MCP responses. Defaults to the server's own
+   * address; set this when MailDev is reached through a different public URL
+   * (e.g. behind a reverse proxy).
+   */
+  webUrl?: string
 }
 
 /**

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -50,6 +50,11 @@ export class MailDevClient {
     }
   }
 
+  /** The configured MailDev API base URL. */
+  getBaseUrl(): string {
+    return this.baseUrl
+  }
+
   private async fetch<T>(path: string, options: RequestInit = {}): Promise<T> {
     const url = `${this.baseUrl}${path}`
     const headers: Record<string, string> = {

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CallToolRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import type { Email } from '@maildev/core'
+import { registerMCPHandlers, type EmailDataSource } from './handlers.js'
+
+/**
+ * Minimal fake MCP Server that records request handlers by schema so tests can
+ * invoke them directly without a transport.
+ */
+function createFakeServer() {
+  const handlers = new Map<unknown, (request: unknown) => Promise<unknown>>()
+  const server = {
+    setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>) {
+      handlers.set(schema, handler)
+    },
+  }
+  return { server, handlers }
+}
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: 'abc123',
+    time: new Date('2024-01-01T00:00:00Z').getTime(),
+    read: true,
+    subject: 'Hello',
+    from: [{ address: 'sender@example.com', name: 'Sender' }],
+    to: [{ address: 'recipient@example.com', name: 'Recipient' }],
+    text: 'body',
+    ...overrides,
+  } as Email
+}
+
+function dataSourceFor(email: Email): EmailDataSource {
+  return {
+    getEmails: async () => [email],
+    getEmail: async () => email,
+    deleteEmail: async () => undefined,
+    getAttachment: async () => Buffer.from(''),
+  } as unknown as EmailDataSource
+}
+
+async function callTool(
+  handlers: Map<unknown, (request: unknown) => Promise<unknown>>,
+  name: string,
+  args: Record<string, unknown> = {}
+): Promise<string> {
+  const handler = handlers.get(CallToolRequestSchema)!
+  const result = (await handler({ params: { name, arguments: args } })) as {
+    content: Array<{ type: string; text: string }>
+  }
+  return result.content.map((c) => c.text).join('\n')
+}
+
+describe('MCP email deep links', () => {
+  it('includes a hash-route URL in get_email output when webUrl is set', async () => {
+    const { server, handlers } = createFakeServer()
+    registerMCPHandlers(server as never, dataSourceFor(makeEmail()), {
+      webUrl: 'http://localhost:1080',
+    })
+
+    const text = await callTool(handlers, 'maildev_get_email', { id: 'abc123' })
+
+    expect(text).toContain('URL: http://localhost:1080/#/email/abc123')
+  })
+
+  it('omits the URL line when no webUrl is configured', async () => {
+    const { server, handlers } = createFakeServer()
+    registerMCPHandlers(server as never, dataSourceFor(makeEmail()))
+
+    const text = await callTool(handlers, 'maildev_get_email', { id: 'abc123' })
+
+    expect(text).not.toContain('URL:')
+  })
+
+  it('encodes ids and strips trailing slashes from the base URL', async () => {
+    const { server, handlers } = createFakeServer()
+    registerMCPHandlers(server as never, dataSourceFor(makeEmail({ id: 'a b/c' })), {
+      webUrl: 'http://localhost:1080/mail/',
+    })
+
+    const text = await callTool(handlers, 'maildev_get_latest_email', {})
+
+    expect(text).toContain('URL: http://localhost:1080/mail/#/email/a%20b%2Fc')
+  })
+
+  it('adds a url field to the email resource JSON', async () => {
+    const { server, handlers } = createFakeServer()
+    registerMCPHandlers(server as never, dataSourceFor(makeEmail()), {
+      webUrl: 'http://localhost:1080',
+    })
+
+    const handler = handlers.get(ReadResourceRequestSchema)!
+    const result = (await handler({ params: { uri: 'maildev://email/abc123' } })) as {
+      contents: Array<{ text: string }>
+    }
+    const payload = JSON.parse(result.contents[0]!.text)
+
+    expect(payload.url).toBe('http://localhost:1080/#/email/abc123')
+  })
+})

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -46,9 +46,21 @@ export interface SearchOptions {
 }
 
 /**
+ * Build a deep link to an email in the MailDev web UI.
+ *
+ * MailDev routes the selected email through a hash fragment
+ * (`#/email/:id`), which keeps the link working under any base path or
+ * reverse-proxy sub-path without server cooperation. `webUrl` is the web UI
+ * base (no trailing slash), e.g. `http://localhost:1080`.
+ */
+function buildEmailWebUrl(webUrl: string, id: string): string {
+  return `${webUrl.replace(/\/+$/, '')}/#/email/${encodeURIComponent(id)}`
+}
+
+/**
  * Format an email for display in MCP responses
  */
-function formatEmailSummary(email: Email): string {
+function formatEmailSummary(email: Email, webUrl?: string): string {
   const from = email.from?.[0]?.address || 'unknown'
   const to = email.to?.map((a) => a.address).join(', ') || 'unknown'
   const date = new Date(email.time).toLocaleString()
@@ -57,8 +69,9 @@ function formatEmailSummary(email: Email): string {
     email.attachments && email.attachments.length > 0
       ? ` [${email.attachments.length} attachment(s)]`
       : ''
+  const url = webUrl ? `\nURL: ${buildEmailWebUrl(webUrl, email.id)}` : ''
 
-  return `ID: ${email.id}
+  return `ID: ${email.id}${url}
 Subject: ${email.subject || '(no subject)'}${read}
 From: ${from}
 To: ${to}
@@ -68,8 +81,8 @@ Date: ${date}${attachments}`
 /**
  * Format full email details
  */
-function formatEmailFull(email: Email): string {
-  const summary = formatEmailSummary(email)
+function formatEmailFull(email: Email, webUrl?: string): string {
+  const summary = formatEmailSummary(email, webUrl)
   const text = email.text || '(no text content)'
   const html = email.html ? '\n\n[HTML content available]' : ''
 
@@ -183,7 +196,22 @@ async function getStats(dataSource: EmailDataSource) {
 /**
  * Register MCP handlers on a server instance
  */
-export function registerMCPHandlers(server: Server, dataSource: EmailDataSource): void {
+/** Options for {@link registerMCPHandlers}. */
+export interface RegisterMCPHandlersOptions {
+  /**
+   * Base URL of the MailDev web UI (no trailing slash). When set, email tool
+   * and resource responses include a deep link so coding agents can hand back
+   * a clickable URL to the message.
+   */
+  webUrl?: string
+}
+
+export function registerMCPHandlers(
+  server: Server,
+  dataSource: EmailDataSource,
+  options: RegisterMCPHandlersOptions = {}
+): void {
+  const { webUrl } = options
   // ===================
   // TOOLS
   // ===================
@@ -316,7 +344,7 @@ export function registerMCPHandlers(server: Server, dataSource: EmailDataSource)
             return { content: [{ type: 'text', text: 'No emails found matching the criteria.' }] }
           }
 
-          const formatted = emails.map(formatEmailSummary).join('\n\n---\n\n')
+          const formatted = emails.map((email) => formatEmailSummary(email, webUrl)).join('\n\n---\n\n')
           return {
             content: [{ type: 'text', text: `Found ${emails.length} email(s):\n\n${formatted}` }],
           }
@@ -325,7 +353,7 @@ export function registerMCPHandlers(server: Server, dataSource: EmailDataSource)
         case 'maildev_get_email': {
           const { id } = args as { id: string }
           const email = await dataSource.getEmail(id)
-          return { content: [{ type: 'text', text: formatEmailFull(email) }] }
+          return { content: [{ type: 'text', text: formatEmailFull(email, webUrl) }] }
         }
 
         case 'maildev_get_latest_email': {
@@ -338,10 +366,10 @@ export function registerMCPHandlers(server: Server, dataSource: EmailDataSource)
 
           const firstEmail = emails[0]
           if (count === 1 && firstEmail) {
-            return { content: [{ type: 'text', text: formatEmailFull(firstEmail) }] }
+            return { content: [{ type: 'text', text: formatEmailFull(firstEmail, webUrl) }] }
           }
 
-          const formatted = emails.map(formatEmailFull).join('\n\n===\n\n')
+          const formatted = emails.map((email) => formatEmailFull(email, webUrl)).join('\n\n===\n\n')
           return { content: [{ type: 'text', text: formatted }] }
         }
 
@@ -448,12 +476,13 @@ export function registerMCPHandlers(server: Server, dataSource: EmailDataSource)
       if (emailMatch && emailMatch[1]) {
         const id = emailMatch[1]
         const email = await dataSource.getEmail(id)
+        const payload = webUrl ? { ...email, url: buildEmailWebUrl(webUrl, id) } : email
         return {
           contents: [
             {
               uri,
               mimeType: 'application/json',
-              text: JSON.stringify(email, null, 2),
+              text: JSON.stringify(payload, null, 2),
             },
           ],
         }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -15,6 +15,21 @@ export interface MailDevMCPServerOptions extends MailDevClientOptions {
   name?: string
   /** Server version */
   version?: string
+  /**
+   * Public base URL of the MailDev web UI (no trailing slash), used to build
+   * email deep links in responses. Defaults to `MAILDEV_WEB_URL`, otherwise
+   * derived from the API base URL.
+   */
+  webUrl?: string
+}
+
+/**
+ * Derive the web UI base URL from the API base URL by dropping a trailing
+ * `/api` segment (REST routes live under `<base>/api`, while the UI is served
+ * from `<base>`). Trailing slashes are stripped so link building is uniform.
+ */
+function deriveWebUrl(apiBaseUrl: string): string {
+  return apiBaseUrl.replace(/\/+$/, '').replace(/\/api$/, '')
 }
 
 /**
@@ -31,7 +46,8 @@ export function createServer(options: MailDevMCPServerOptions = {}): Server {
   )
 
   // Register handlers using the HTTP client as the data source
-  registerMCPHandlers(server, client)
+  const webUrl = options.webUrl || process.env.MAILDEV_WEB_URL || deriveWebUrl(client.getBaseUrl())
+  registerMCPHandlers(server, client, { webUrl })
 
   return server
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,6 @@
     "clsx": "^2.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.1",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.0",
     "zustand": "^5.0.0"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from './stores/ui'
 import { useEmailList, useMarkReadOnOpen } from './hooks/useEmails'
 import { useFaviconBadge } from './hooks/useFaviconBadge'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { useEmailRoute } from './hooks/useEmailRoute'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -31,6 +32,9 @@ function AppContent() {
 
   // Reflect the read state the server sets when an email is opened
   useMarkReadOnOpen()
+
+  // Deep-link the selected email and follow browser back/forward navigation
+  useEmailRoute()
 
   // Apply theme class to document
   useEffect(() => {

--- a/packages/ui/src/components/email-list/SearchInput.tsx
+++ b/packages/ui/src/components/email-list/SearchInput.tsx
@@ -20,7 +20,9 @@ export function SearchInput() {
     if (searchQuery !== prevSearchQueryRef.current) {
       prevSearchQueryRef.current = searchQuery
       if (searchQuery && visibleEmails.length > 0) {
-        setSelectedEmail(visibleEmails[0]!.id)
+        // Auto-selecting the top match as the user types is a side-effect of
+        // filtering, not deliberate navigation, so replace instead of push.
+        setSelectedEmail(visibleEmails[0]!.id, { replace: true })
       }
     }
   }, [searchQuery, visibleEmails, setSelectedEmail])

--- a/packages/ui/src/hooks/useCommands.tsx
+++ b/packages/ui/src/hooks/useCommands.tsx
@@ -255,7 +255,9 @@ export function useCommands(): Command[] {
         action: () => {
           if (selectedEmailId && window.confirm('Delete this email?')) {
             api.emails.delete(selectedEmailId).then(() => {
-              setSelectedEmail(null)
+              // The deleted email's route is gone; replace so Back doesn't
+              // return to a now-404 selection.
+              setSelectedEmail(null, { replace: true })
               refresh()
             })
           }

--- a/packages/ui/src/hooks/useEmailRoute.test.ts
+++ b/packages/ui/src/hooks/useEmailRoute.test.ts
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '../stores/ui'
+import { useEmailRoute } from './useEmailRoute'
+
+describe('useEmailRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '#/')
+    useUIStore.getState().syncSelectedEmailFromRoute(null)
+  })
+
+  it('updates the route when an email is selected', () => {
+    renderHook(() => useEmailRoute())
+
+    act(() => useUIStore.getState().setSelectedEmail('email-123'))
+
+    expect(window.location.hash).toBe('#/email/email-123')
+  })
+
+  it('updates the selection when the hash route changes', () => {
+    renderHook(() => useEmailRoute())
+
+    act(() => {
+      window.history.pushState(null, '', '#/email/email-456')
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    })
+
+    expect(useUIStore.getState().selectedEmailId).toBe('email-456')
+  })
+})

--- a/packages/ui/src/hooks/useEmailRoute.ts
+++ b/packages/ui/src/hooks/useEmailRoute.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { parseEmailRoute } from '../lib/emailRoute'
+import { useUIStore } from '../stores/ui'
+
+/** Keep browser back/forward navigation in sync with the selected email. */
+export function useEmailRoute(): void {
+  useEffect(() => {
+    const syncSelectionFromRoute = () => {
+      useUIStore.getState().syncSelectedEmailFromRoute(parseEmailRoute(window.location.hash))
+    }
+
+    syncSelectionFromRoute()
+    window.addEventListener('hashchange', syncSelectionFromRoute)
+    return () => window.removeEventListener('hashchange', syncSelectionFromRoute)
+  }, [])
+}

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -113,7 +113,9 @@ export function useKeyboardShortcuts() {
               const nextEmail = visibleEmails[nextIndex]
 
               api.emails.delete(selectedEmailId).then(() => {
-                setSelectedEmail(nextEmail?.id ?? null)
+                // The deleted email's route is gone; replace so Back doesn't
+                // return to a now-404 selection.
+                setSelectedEmail(nextEmail?.id ?? null, { replace: true })
                 refresh()
               })
             }

--- a/packages/ui/src/hooks/useSocket.ts
+++ b/packages/ui/src/hooks/useSocket.ts
@@ -110,9 +110,10 @@ export function useSocket() {
         showNotification(email, setSelectedEmailRef.current)
       }
 
-      // Auto-show new mail if enabled
+      // Auto-show new mail if enabled. Replace rather than push so a stream of
+      // arriving mail the user didn't act on doesn't flood browser history.
       if (autoShowNewMailRef.current) {
-        setSelectedEmailRef.current(email.id)
+        setSelectedEmailRef.current(email.id, { replace: true })
       }
     })
 

--- a/packages/ui/src/lib/emailRoute.test.ts
+++ b/packages/ui/src/lib/emailRoute.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildEmailRoute, parseEmailRoute } from './emailRoute'
+
+describe('email dashboard routes', () => {
+  it('builds and parses the MailDev email route', () => {
+    const hash = buildEmailRoute('email id/with/slashes')
+
+    expect(hash).toBe('#/email/email%20id%2Fwith%2Fslashes')
+    expect(parseEmailRoute(hash)).toBe('email id/with/slashes')
+  })
+
+  it('uses the dashboard route when no email is selected', () => {
+    expect(buildEmailRoute(null)).toBe('#/')
+    expect(parseEmailRoute('#/')).toBeNull()
+  })
+
+  it('rejects malformed or unrelated routes', () => {
+    expect(parseEmailRoute('#/email/')).toBeNull()
+    expect(parseEmailRoute('#/email/not/one-id')).toBeNull()
+    expect(parseEmailRoute('#/settings')).toBeNull()
+    expect(parseEmailRoute('#/email/%E0%A4%A')).toBeNull()
+  })
+})

--- a/packages/ui/src/lib/emailRoute.test.ts
+++ b/packages/ui/src/lib/emailRoute.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { buildEmailRoute, parseEmailRoute } from './emailRoute'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { buildEmailRoute, parseEmailRoute, updateEmailRoute } from './emailRoute'
 
 describe('email dashboard routes', () => {
   it('builds and parses the MailDev email route', () => {
@@ -19,5 +19,38 @@ describe('email dashboard routes', () => {
     expect(parseEmailRoute('#/email/not/one-id')).toBeNull()
     expect(parseEmailRoute('#/settings')).toBeNull()
     expect(parseEmailRoute('#/email/%E0%A4%A')).toBeNull()
+  })
+})
+
+describe('updateEmailRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '#/')
+  })
+
+  it('pushes a new history entry by default', () => {
+    const before = window.history.length
+
+    updateEmailRoute('abc123')
+
+    expect(window.location.hash).toBe('#/email/abc123')
+    expect(window.history.length).toBe(before + 1)
+  })
+
+  it('replaces the current entry when asked', () => {
+    const before = window.history.length
+
+    updateEmailRoute('abc123', { replace: true })
+
+    expect(window.location.hash).toBe('#/email/abc123')
+    expect(window.history.length).toBe(before)
+  })
+
+  it('is a no-op when the route already matches', () => {
+    updateEmailRoute('abc123')
+    const length = window.history.length
+
+    updateEmailRoute('abc123')
+
+    expect(window.history.length).toBe(length)
   })
 })

--- a/packages/ui/src/lib/emailRoute.ts
+++ b/packages/ui/src/lib/emailRoute.ts
@@ -1,0 +1,34 @@
+const EMAIL_ROUTE_PREFIX = '#/email/'
+
+/** Return the selected email ID encoded in a dashboard hash route. */
+export function parseEmailRoute(hash: string): string | null {
+  if (!hash.startsWith(EMAIL_ROUTE_PREFIX)) {
+    return null
+  }
+
+  const encodedId = hash.slice(EMAIL_ROUTE_PREFIX.length)
+  if (!encodedId || encodedId.includes('/')) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(encodedId)
+  } catch {
+    return null
+  }
+}
+
+/** Build a dashboard hash route compatible with MailDev 2.x email links. */
+export function buildEmailRoute(id: string | null): string {
+  return id ? `${EMAIL_ROUTE_PREFIX}${encodeURIComponent(id)}` : '#/'
+}
+
+/** Update the browser route without adding duplicate history entries. */
+export function updateEmailRoute(id: string | null): void {
+  if (typeof window === 'undefined') return
+
+  const nextHash = buildEmailRoute(id)
+  if (window.location.hash !== nextHash) {
+    window.location.hash = nextHash
+  }
+}

--- a/packages/ui/src/lib/emailRoute.ts
+++ b/packages/ui/src/lib/emailRoute.ts
@@ -23,12 +23,32 @@ export function buildEmailRoute(id: string | null): string {
   return id ? `${EMAIL_ROUTE_PREFIX}${encodeURIComponent(id)}` : '#/'
 }
 
-/** Update the browser route without adding duplicate history entries. */
-export function updateEmailRoute(id: string | null): void {
+/**
+ * Update the browser route to reflect the selected email.
+ *
+ * Uses `pushState` by default so deliberate opens are retraceable with the
+ * browser back/forward buttons. Pass `{ replace: true }` for selection changes
+ * that are side-effects rather than navigation the user should be able to walk
+ * back through (auto-showing arriving mail, search auto-select, reselecting
+ * after a delete) so they don't flood the history stack.
+ *
+ * Neither `pushState` nor `replaceState` fires a `hashchange` event, so callers
+ * are responsible for updating the selection state themselves; genuine
+ * back/forward navigation still fires `hashchange` and is handled by
+ * {@link useEmailRoute}.
+ */
+export function updateEmailRoute(
+  id: string | null,
+  options: { replace?: boolean } = {}
+): void {
   if (typeof window === 'undefined') return
 
   const nextHash = buildEmailRoute(id)
-  if (window.location.hash !== nextHash) {
-    window.location.hash = nextHash
+  if (window.location.hash === nextHash) return
+
+  if (options.replace) {
+    window.history.replaceState(null, '', nextHash)
+  } else {
+    window.history.pushState(null, '', nextHash)
   }
 }

--- a/packages/ui/src/stores/ui.ts
+++ b/packages/ui/src/stores/ui.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { parseEmailRoute, updateEmailRoute } from '../lib/emailRoute'
 
 interface UIState {
   /** Currently selected email ID */
@@ -21,6 +22,7 @@ interface UIState {
 
   // Actions
   setSelectedEmail: (id: string | null) => void
+  syncSelectedEmailFromRoute: (id: string | null) => void
   toggleTheme: () => void
   setTheme: (theme: 'light' | 'dark') => void
   setSearchQuery: (query: string) => void
@@ -35,7 +37,7 @@ interface UIState {
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
-      selectedEmailId: null,
+      selectedEmailId: typeof window === 'undefined' ? null : parseEmailRoute(window.location.hash),
       theme: 'light',
       searchQuery: '',
       sidebarCollapsed: false,
@@ -44,7 +46,12 @@ export const useUIStore = create<UIState>()(
       loadingBarEnabled: true,
       commandPaletteOpen: false,
 
-      setSelectedEmail: (id) => set({ selectedEmailId: id }),
+      setSelectedEmail: (id) => {
+        set({ selectedEmailId: id })
+        updateEmailRoute(id)
+      },
+
+      syncSelectedEmailFromRoute: (id) => set({ selectedEmailId: id }),
 
       toggleTheme: () =>
         set((state) => ({

--- a/packages/ui/src/stores/ui.ts
+++ b/packages/ui/src/stores/ui.ts
@@ -21,7 +21,7 @@ interface UIState {
   commandPaletteOpen: boolean
 
   // Actions
-  setSelectedEmail: (id: string | null) => void
+  setSelectedEmail: (id: string | null, options?: { replace?: boolean }) => void
   syncSelectedEmailFromRoute: (id: string | null) => void
   toggleTheme: () => void
   setTheme: (theme: 'light' | 'dark') => void
@@ -46,9 +46,9 @@ export const useUIStore = create<UIState>()(
       loadingBarEnabled: true,
       commandPaletteOpen: false,
 
-      setSelectedEmail: (id) => {
+      setSelectedEmail: (id, options) => {
         set({ selectedEmailId: id })
-        updateEmailRoute(id)
+        updateEmailRoute(id, options)
       },
 
       syncSelectedEmailFromRoute: (id) => set({ selectedEmailId: id }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,9 +244,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
@@ -2676,23 +2673,6 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
-
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -5643,20 +5623,6 @@ snapshots:
   react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
-
-  react-router-dom@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-
-  react-router@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.3
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
 
   react@19.2.3: {}
 


### PR DESCRIPTION
Builds upon #543 from @w3lld1 to land dashboard routes and improves on some key areas:

- Route with pushState/replaceState so deliberate opens are retraceable via browser back/forward, while side-effect selections (auto-show new mail, search auto-select, post-delete reselection) replace instead of pushing so they don't flood history.
- Expose email deep links over MCP: get_email/get_latest_email/search output and the `maildev://email/{id}` resource include a hash-route URL (immune to base-path/reverse-proxy). Integrated HTTP transport derives it from the server address (overridable via MCPConfig.webUrl); the stdio server derives it from `MAILDEV_API_URL` or `MAILDEV_WEB_URL`.
- Drop the now-unused react-router-dom dependency.
- Tests for push vs replace and MCP URL output; docs updated.