### PR TITLE
docs: document relay delivery status fields

### DIFF
--- a/.changeset/persist-relay-status.md
+++ b/.changeset/persist-relay-status.md
@@ -1,0 +1,19 @@
+---
+'@maildev/core': patch
+'@maildev/smtp': patch
+---
+
+Persist relay delivery status across restarts
+
+`relayedAt`/`relayedTo` were kept only in memory, so a restart lost the record
+of whether a message had been relayed. Disk-backed storage now writes a small
+per-email metadata sidecar (`<id>.meta.json`) next to the `.eml`, and
+`loadMailsFromDirectory` reads it back when restoring, so relay status survives
+a restart. The sidecar holds post-receipt state that can't be recovered by
+re-parsing the message and is a natural home for future persisted fields; it is
+removed with the email on delete, bulk delete and `maxEmails` eviction.
+In-memory storage is unaffected.
+
+- `@maildev/core`: `FileStorage` persists email metadata; a new `EmailMetadata`
+  type describes the persisted shape and the optional `Storage.readMetadata(id)`
+  exposes it for restore.

--- a/docs/api.md
+++ b/docs/api.md
@@ -250,6 +250,8 @@ interface Email {
   priority?: 'high' | 'normal' | 'low'
   attachments: Attachment[]
   envelope: Envelope
+  relayedAt?: Date      // when the email was last successfully relayed
+  relayedTo?: string[]  // recipients delivered to on the last successful relay
 }
 
 interface Address {
@@ -304,6 +306,19 @@ smtp.on('new', async (email) => {
   }
 })
 ```
+
+After a successful relay (manual or auto) the email records `relayedAt` and
+`relayedTo`, so you can tell whether and where a message was delivered:
+
+```typescript
+const email = await smtp.getEmail('email-id')
+if (email.relayedAt) {
+  console.log(`Relayed at ${email.relayedAt} to ${email.relayedTo?.join(', ')}`)
+}
+```
+
+With `FileStorage` this status is persisted to disk and restored on startup;
+with in-memory storage it lives only for the lifetime of the process.
 
 ### Auto-Relay
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -56,9 +56,15 @@ Returns:
     "remoteAddress": "127.0.0.1"
   },
   "size": 1024,
-  "sizeHuman": "1 KB"
+  "sizeHuman": "1 KB",
+  "relayedAt": "2026-01-05T19:05:11.482Z",
+  "relayedTo": ["johnny.utah@fbi.gov"]
 }]
 ```
+
+`relayedAt` and `relayedTo` are only present once an email has been relayed to
+the outgoing server (see the relay endpoint below); they are omitted for
+messages that have never been relayed.
 
 ## Endpoints
 
@@ -90,7 +96,12 @@ attachments
 attachment
 
 **POST   /api/email/:id/relay/:relayTo?** - If configured, relay a given email to
-its real "to" address, or to the optional `relayTo` recipient override
+its real "to" address, or to the optional `relayTo` recipient override. On
+success the email records `relayedAt` (timestamp of the last successful relay)
+and `relayedTo` (the recipients it was delivered to), returned by the endpoints
+above. When a mail directory is configured (file storage), this status is
+persisted to disk and survives a restart; with in-memory storage it is kept
+only for the lifetime of the process.
 
 **GET    /api/reloadMailsFromDirectory** - Reload emails from the configured mail
 directory

--- a/packages/core/src/__tests__/file-storage.test.ts
+++ b/packages/core/src/__tests__/file-storage.test.ts
@@ -124,6 +124,67 @@ describe('FileStorage', () => {
     })
   })
 
+  describe('metadata sidecar', () => {
+    it('persists relay status to a sidecar and reads it back', async () => {
+      storage = new FileStorage({ mailDirectory })
+      await storage.initialize()
+
+      const relayedAt = new Date('2026-01-02T03:04:05.000Z')
+      await storage.save(
+        createTestEmail('relayed', { relayedAt, relayedTo: ['b@example.com'] })
+      )
+      await writeEmailFiles('relayed')
+
+      expect(existsSync(join(mailDirectory, 'relayed.meta.json'))).toBe(true)
+
+      const meta = await storage.readMetadata('relayed')
+      expect(meta?.relayedAt).toEqual(relayedAt)
+      expect(meta?.relayedTo).toEqual(['b@example.com'])
+    })
+
+    it('writes no sidecar for an email with no persisted metadata', async () => {
+      storage = new FileStorage({ mailDirectory })
+      await storage.initialize()
+
+      await storage.save(createTestEmail('plain'))
+
+      expect(existsSync(join(mailDirectory, 'plain.meta.json'))).toBe(false)
+      expect(await storage.readMetadata('plain')).toBeNull()
+    })
+
+    it('removes the sidecar when the email is deleted', async () => {
+      storage = new FileStorage({ mailDirectory })
+      await storage.initialize()
+
+      await storage.save(
+        createTestEmail('gone', { relayedAt: new Date(), relayedTo: ['b@example.com'] })
+      )
+      expect(existsSync(join(mailDirectory, 'gone.meta.json'))).toBe(true)
+
+      await storage.delete('gone')
+      expect(existsSync(join(mailDirectory, 'gone.meta.json'))).toBe(false)
+    })
+
+    it('sweeps sidecars on deleteAll and eviction', async () => {
+      storage = new FileStorage({ mailDirectory, maxEmails: 1 })
+      await storage.initialize()
+
+      await storage.save(
+        createTestEmail('first', { relayedAt: new Date(), relayedTo: ['b@example.com'] })
+      )
+      await writeEmailFiles('first')
+      // Evicts 'first', whose sidecar must go with it
+      await storage.save(
+        createTestEmail('second', { relayedAt: new Date(), relayedTo: ['c@example.com'] })
+      )
+      await writeEmailFiles('second')
+      expect(existsSync(join(mailDirectory, 'first.meta.json'))).toBe(false)
+
+      await storage.deleteAll()
+      expect(await readdir(mailDirectory)).toEqual([])
+    })
+  })
+
   describe('source path', () => {
     it('should point source at the storage directory', async () => {
       storage = new FileStorage({ mailDirectory })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export type {
   Email,
   EmailInput,
   EmailSummary,
+  EmailMetadata,
   StorageQuery,
   StorageOptions,
   Storage,

--- a/packages/core/src/storage/file.ts
+++ b/packages/core/src/storage/file.ts
@@ -1,7 +1,7 @@
-import { mkdir, rm, readdir } from 'node:fs/promises'
+import { mkdir, rm, readdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
-import type { Email, StorageOptions } from '../types/index.js'
+import type { Email, EmailMetadata, StorageOptions } from '../types/index.js'
 import { mapLimit } from '../utils/concurrency.js'
 import { MemoryStorage } from './memory.js'
 
@@ -55,6 +55,20 @@ export class FileStorage extends MemoryStorage {
       await mkdir(attachmentDir, { recursive: true })
     }
 
+    // Persist any post-receipt state (relay status today) in a metadata sidecar
+    // so it survives a restart. The raw .eml can't carry it, so it lives beside
+    // the .eml and is read back by loadMailsFromDirectory. The store routes
+    // every mutation through save(), so writing the whole projection here keeps
+    // the sidecar in step without needing partial updates.
+    const metadata = this.buildMetadata(email)
+    if (metadata) {
+      await writeFile(
+        this.getMetadataPath(email.id),
+        JSON.stringify(metadata),
+        'utf8'
+      )
+    }
+
     // Note: Actual .eml file writing will be handled by SMTP package
     // This package provides the storage abstraction and directory management
   }
@@ -83,7 +97,10 @@ export class FileStorage extends MemoryStorage {
     try {
       const entries = await readdir(this.mailDirectory, { withFileTypes: true })
       const removable = entries.filter(
-        (entry) => entry.isDirectory() || entry.name.endsWith('.eml')
+        (entry) =>
+          entry.isDirectory() ||
+          entry.name.endsWith('.eml') ||
+          entry.name.endsWith('.meta.json')
       )
 
       // Bounded concurrency: a directory holding tens of thousands of emails
@@ -128,6 +145,60 @@ export class FileStorage extends MemoryStorage {
   }
 
   /**
+   * Get the path to an email's metadata sidecar
+   */
+  private getMetadataPath(id: string): string {
+    this.assertSafeEmailId(id)
+    return join(this.mailDirectory, `${id}.meta.json`)
+  }
+
+  /**
+   * Project the persisted-metadata fields out of an email
+   *
+   * Returns null when there's nothing to persist. Each persisted field adds a
+   * block here; the shape mirrors {@link EmailMetadata}.
+   */
+  private buildMetadata(email: Email): EmailMetadata | null {
+    const metadata: EmailMetadata = {}
+    if (email.relayedAt) {
+      metadata.relayedAt = email.relayedAt
+      metadata.relayedTo = email.relayedTo ?? []
+    }
+    return Object.keys(metadata).length > 0 ? metadata : null
+  }
+
+  /**
+   * Read the persisted metadata for an email, if any
+   *
+   * Used when restoring emails from disk so state recorded in a previous
+   * session (e.g. a relay) is not lost. Returns null when no sidecar exists or
+   * it is unreadable.
+   * @param id - Email ID
+   */
+  async readMetadata(id: string): Promise<EmailMetadata | null> {
+    let raw: string
+    try {
+      raw = await readFile(this.getMetadataPath(id), 'utf8')
+    } catch {
+      // No sidecar: no metadata was ever recorded for this email.
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as { relayedAt?: string; relayedTo?: string[] }
+      const metadata: EmailMetadata = {}
+      if (parsed.relayedAt) {
+        metadata.relayedAt = new Date(parsed.relayedAt)
+        metadata.relayedTo = parsed.relayedTo ?? []
+      }
+      return Object.keys(metadata).length > 0 ? metadata : null
+    } catch {
+      // A corrupt sidecar shouldn't stop the email from being restored.
+      return null
+    }
+  }
+
+  /**
    * Guard against an id that would escape the mail directory
    *
    * Throws unless both `<id>.eml` and `<id>/` resolve to paths inside
@@ -163,6 +234,7 @@ export class FileStorage extends MemoryStorage {
     try {
       await rm(this.getEmailPath(id), { force: true })
       await rm(this.getAttachmentDirectory(id), { recursive: true, force: true })
+      await rm(this.getMetadataPath(id), { force: true })
     } catch {
       // Ignore errors if files don't exist
     }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -12,6 +12,7 @@ export type {
 
 // Storage types
 export type {
+  EmailMetadata,
   StorageQuery,
   StorageOptions,
   Storage,

--- a/packages/core/src/types/storage.ts
+++ b/packages/core/src/types/storage.ts
@@ -1,6 +1,16 @@
 import type { Email } from './email.js'
 
 /**
+ * Per-email state persisted outside the raw `.eml` message
+ *
+ * Everything here is state set after receipt that can't be recovered by
+ * re-parsing the message (relay status today; a natural home for future
+ * mutable fields). Disk-backed storage writes it to a per-email metadata
+ * sidecar and restores it on startup. Extend this type as fields are added.
+ */
+export type EmailMetadata = Pick<Email, 'relayedAt' | 'relayedTo'>
+
+/**
  * Query object for filtering emails
  * Supports dot-notation for nested properties (e.g., "from.address")
  */
@@ -161,6 +171,15 @@ export interface Storage {
    * @returns Function that unregisters the handler
    */
   onEvicted(handler: EvictHandler): () => void
+
+  /**
+   * Read persisted metadata for an email, if the backend keeps any
+   *
+   * Only disk-backed storage implements this; in-memory storage has nothing to
+   * restore. Returns null when no metadata has been recorded for the email.
+   * @param id - Email ID
+   */
+  readMetadata?(id: string): Promise<EmailMetadata | null>
 
   // Lifecycle
 

--- a/packages/smtp/src/__tests__/relay.test.ts
+++ b/packages/smtp/src/__tests__/relay.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import net, { type AddressInfo } from 'node:net'
 import nodemailer from 'nodemailer'
-import { MemoryStorage } from '@maildev/core'
+import { MemoryStorage, FileStorage } from '@maildev/core'
 import { SMTPServer } from '../server.js'
 
 /** Grab an ephemeral free port so parallel test files don't collide. */
@@ -81,5 +81,31 @@ describe('relay delivery status', () => {
     const stored = (await destStore.getAll())[0]!
     expect(stored.relayedAt).toBeUndefined()
     expect(stored.relayedTo).toBeUndefined()
+  })
+
+  it('restores relay status from disk on a fresh FileStorage-backed server', async () => {
+    // Use a disk-backed source so the relay status is persisted to a sidecar.
+    await source.stop()
+    const fileStore = new FileStorage({ mailDirectory: sourceDir })
+    await fileStore.initialize()
+    source = new SMTPServer({ storage: fileStore, mailDir: sourceDir, port: sourcePort, host: '127.0.0.1' })
+    await source.start()
+    source.setupRelay({ host: '127.0.0.1', port: destPort, secure: false })
+    source.setAutoRelay({ enabled: true })
+
+    await sendTo(sourcePort)
+    const id = (await fileStore.getAll())[0]!.id
+    expect((await fileStore.getById(id))!.relayedAt).toBeInstanceOf(Date)
+
+    // Simulate a restart: a brand-new store + server reading the same directory.
+    await source.stop()
+    const restoredStore = new FileStorage({ mailDirectory: sourceDir })
+    await restoredStore.initialize()
+    source = new SMTPServer({ storage: restoredStore, mailDir: sourceDir, port: sourcePort, host: '127.0.0.1' })
+    await source.loadMailsFromDirectory()
+
+    const restored = (await restoredStore.getById(id))!
+    expect(restored.relayedAt).toBeInstanceOf(Date)
+    expect(restored.relayedTo).toContain('b@example.com')
   })
 })

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -12,7 +12,7 @@ import { rm, readdir, readFile, writeFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { PassThrough, Transform, type Readable } from 'node:stream'
-import { formatBytes, calculateBcc, makeId, mapLimit, type Storage, type Email, type Attachment } from '@maildev/core'
+import { formatBytes, calculateBcc, makeId, mapLimit, type Storage, type Email, type EmailMetadata, type Attachment } from '@maildev/core'
 import { parseEmailStream, parseEmailBuffer } from './parser.js'
 import { createAuthCallback } from './auth.js'
 import { createLogger } from './logger.js'
@@ -429,7 +429,9 @@ export class SMTPServer extends EventEmitter {
         }
 
         try {
-          await this.saveEmail(id, envelope, parsed, true)
+          // Restore any metadata persisted alongside the .eml.
+          const metadata = await this.storage.readMetadata?.(id)
+          await this.saveEmail(id, envelope, parsed, true, metadata)
         } catch (err) {
           this.logger.error(`Error restoring email ${id}:`, err)
         }
@@ -656,7 +658,8 @@ export class SMTPServer extends EventEmitter {
     id: string,
     envelope: StoredEnvelope,
     parsed: ParsedEmail,
-    isRestored = false
+    isRestored = false,
+    metadata?: EmailMetadata | null
   ): Promise<Email> {
     const emlPath = join(this.mailDir, `${id}.eml`)
     const emlStat = await stat(emlPath)
@@ -732,6 +735,12 @@ export class SMTPServer extends EventEmitter {
     }
     if (parsed.priority) {
       email.priority = parsed.priority
+    }
+
+    // Carry forward metadata persisted in a previous session (restore only).
+    if (metadata?.relayedAt) {
+      email.relayedAt = metadata.relayedAt
+      email.relayedTo = metadata.relayedTo ?? []
     }
 
     await this.storage.save(email)


### PR DESCRIPTION
Stacked on #570 (which is stacked on #569). **Merge #569 then #570 first.**

## What
Documents the `relayedAt` / `relayedTo` fields introduced in #569 and persisted in #570.

- **`docs/rest.md`** — adds both fields to the example email response, notes they're only present once relayed, and expands the relay endpoint description to cover the recorded status and its persistence behavior.
- **`docs/api.md`** — adds the fields to the `Email` interface and shows reading relay status after `relayEmail`, plus a note on file vs in-memory persistence.

Docs-only; no changeset (no package version change).