### PR TITLE
Use https in package metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "smtp"
   ],
   "author": "Dan Farrelly",
-  "homepage": "http://maildev.github.io/maildev/",
+  "homepage": "https://maildev.github.io/maildev/",
   "maintainers": [
     {
       "name": "Dan Farrelly",
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git"
+    "url": "https://github.com/maildev/maildev.git"
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/api"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,10 +39,10 @@
   ],
   "author": "Dan Farrelly",
   "license": "MIT",
-  "homepage": "http://maildev.github.io/maildev/",
+  "homepage": "https://maildev.github.io/maildev/",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/cli"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/core"
   },
   "engines": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/mcp"
   },
   "engines": {

--- a/packages/smtp/package.json
+++ b/packages/smtp/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/smtp"
   },
   "engines": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/maildev/maildev.git",
+    "url": "https://github.com/maildev/maildev.git",
     "directory": "packages/ui"
   },
   "engines": {


### PR DESCRIPTION
All seven `package.json` files referenced `github.com` and the docs site over plain `http://`.

The `homepage` field in `packages/cli/package.json` is the one that matters most — it is what npmjs.com renders as the package's homepage link for `maildev`, so it was pointing the most-clicked inbound link the project has at an unencrypted URL.

Enforce HTTPS is now enabled on the `maildev/maildev` Pages site, so `http://maildev.github.io/maildev/` does `301` to HTTPS. This change makes the metadata name the canonical URL directly instead of depending on that redirect.

### Changes

| File | Field(s) |
|---|---|
| `package.json` | `homepage`, `repository.url` |
| `packages/cli/package.json` | `homepage`, `repository.url` |
| `packages/{api,core,mcp,smtp,ui}/package.json` | `repository.url` |

9 replacements, metadata only — no behaviour or dependency changes. The published values update with the next release.

### Note

`repository.url` uses the plain `https://…​.git` form here to keep the diff to a scheme change. npm's own convention is `git+https://…​.git`; npm normalizes both, so switching is optional if you'd prefer the canonical form.