### PR TITLE
fix: Restore v2 inline "click again to confirm" for delete all (#576)

### DIFF
--- a/.changeset/delete-confirmation-v2-parity.md
+++ b/.changeset/delete-confirmation-v2-parity.md
@@ -1,0 +1,10 @@
+---
+'@maildev/ui': patch
+---
+
+Restore v2's lighter-weight email deletion UX. "Delete all emails" no longer
+opens a blocking confirmation dialog — the first click arms the button (it turns
+red and slides open to "Confirm") and a second click within 2 seconds clears the
+inbox, otherwise it resets. Deleting a single email now happens immediately on
+click without a prompt, matching v2. Clearing the inbox also resets the reading
+pane so a deleted email no longer lingers on screen.

--- a/packages/ui/src/components/email-viewer/EmailHeader.tsx
+++ b/packages/ui/src/components/email-viewer/EmailHeader.tsx
@@ -56,8 +56,6 @@ export function EmailHeader({ email }: EmailHeaderProps) {
   const bccAddresses = email.calculatedBcc?.map(formatEmailAddress).join(', ')
 
   const handleDelete = async () => {
-    // Test emails are disposable and easily regenerated, so delete on click
-    // without a confirmation prompt (matching v2 behavior).
     await deleteMutation.mutateAsync(email.id)
     setSelectedEmail(null)
   }

--- a/packages/ui/src/components/email-viewer/EmailHeader.tsx
+++ b/packages/ui/src/components/email-viewer/EmailHeader.tsx
@@ -56,10 +56,10 @@ export function EmailHeader({ email }: EmailHeaderProps) {
   const bccAddresses = email.calculatedBcc?.map(formatEmailAddress).join(', ')
 
   const handleDelete = async () => {
-    if (window.confirm('Are you sure you want to delete this email?')) {
-      await deleteMutation.mutateAsync(email.id)
-      setSelectedEmail(null)
-    }
+    // Test emails are disposable and easily regenerated, so delete on click
+    // without a confirmation prompt (matching v2 behavior).
+    await deleteMutation.mutateAsync(email.id)
+    setSelectedEmail(null)
   }
 
   const handleDownload = () => {

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -13,6 +13,12 @@ export function Header() {
   const [showSettings, setShowSettings] = useState(false)
   const settingsRef = useRef<HTMLDivElement>(null)
 
+  // Inline "click again to confirm" safeguard for delete-all (restores v2 behavior).
+  const [deleteAllArmed, setDeleteAllArmed] = useState(false)
+  const deleteAllTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setSelectedEmail = useUIStore((state) => state.setSelectedEmail)
+
   const theme = useUIStore((state) => state.theme)
   const toggleTheme = useUIStore((state) => state.toggleTheme)
   const toggleSidebar = useUIStore((state) => state.toggleSidebar)
@@ -54,11 +60,38 @@ export function Header() {
     }
   }
 
+  // First click arms the button (it slides open to "Confirm: Yes" and turns red)
+  // and starts a 2s timer; a second click within that window deletes everything.
+  // If the window lapses, the button quietly resets to its idle state.
   const handleDeleteAll = () => {
-    if (window.confirm('Are you sure you want to delete all emails?')) {
-      deleteAllMutation.mutate()
+    if (!deleteAllArmed) {
+      setDeleteAllArmed(true)
+      deleteAllTimer.current = setTimeout(() => {
+        setDeleteAllArmed(false)
+        deleteAllTimer.current = null
+      }, 2000)
+      return
     }
+
+    if (deleteAllTimer.current) {
+      clearTimeout(deleteAllTimer.current)
+      deleteAllTimer.current = null
+    }
+    setDeleteAllArmed(false)
+    deleteAllMutation.mutate(undefined, {
+      // Clear the reading pane so a deleted email can't linger on screen.
+      onSuccess: () => setSelectedEmail(null),
+    })
   }
+
+  // Clean up the pending safeguard timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (deleteAllTimer.current) {
+        clearTimeout(deleteAllTimer.current)
+      }
+    }
+  }, [])
 
   const handleMarkAllRead = () => {
     markAllReadMutation.mutate()
@@ -162,20 +195,25 @@ export function Header() {
         </Tooltip>
 
         {/* Delete all */}
-        <Tooltip content="Delete all emails" position="left">
+        <Tooltip
+          content={deleteAllArmed ? 'Click again to delete all emails' : 'Delete all emails'}
+          position="left"
+        >
           <button
             onClick={handleDeleteAll}
             disabled={deleteAllMutation.isPending}
             className={cn(
-              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-              'text-[hsl(var(--destructive))] hover:bg-[hsl(var(--destructive)/0.1)]',
+              'flex items-center overflow-hidden rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-300 ease-out',
+              deleteAllArmed
+                ? 'bg-[hsl(var(--destructive))] text-[hsl(var(--destructive-foreground))]'
+                : 'text-[hsl(var(--destructive))] hover:bg-[hsl(var(--destructive)/0.1)]',
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
-            aria-label="Delete all emails"
+            aria-label={deleteAllArmed ? 'Confirm delete all emails' : 'Delete all emails'}
             data-testid="delete-all-button"
           >
             <svg
-              className="h-4 w-4"
+              className="h-4 w-4 shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -187,6 +225,14 @@ export function Header() {
                 d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
               />
             </svg>
+            <span
+              className={cn(
+                'overflow-hidden whitespace-nowrap transition-all duration-300 ease-out',
+                deleteAllArmed ? 'ml-2 max-w-[8rem] opacity-100' : 'ml-0 max-w-0 opacity-0'
+              )}
+            >
+              Confirm: Yes
+            </span>
           </button>
         </Tooltip>
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -231,7 +231,7 @@ export function Header() {
                 deleteAllArmed ? 'ml-2 max-w-[8rem] opacity-100' : 'ml-0 max-w-0 opacity-0'
               )}
             >
-              Confirm: Yes
+              Confirm
             </span>
           </button>
         </Tooltip>

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
   const [showSettings, setShowSettings] = useState(false)
   const settingsRef = useRef<HTMLDivElement>(null)
 
-  // Inline "click again to confirm" safeguard for delete-all (restores v2 behavior).
+  // Inline "click again to confirm" safeguard for delete-all
   const [deleteAllArmed, setDeleteAllArmed] = useState(false)
   const deleteAllTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -60,9 +60,8 @@ export function Header() {
     }
   }
 
-  // First click arms the button (it slides open to "Confirm: Yes" and turns red)
-  // and starts a 2s timer; a second click within that window deletes everything.
-  // If the window lapses, the button quietly resets to its idle state.
+  // First click "arms" the button which transitions to "Confirm" for 2 seconds
+  // otherwise reverting state
   const handleDeleteAll = () => {
     if (!deleteAllArmed) {
       setDeleteAllArmed(true)

--- a/packages/ui/src/hooks/useCommands.tsx
+++ b/packages/ui/src/hooks/useCommands.tsx
@@ -226,9 +226,10 @@ export function useCommands(): Command[] {
         category: 'email',
         icon: <TrashIcon />,
         action: () => {
-          if (window.confirm('Are you sure you want to delete all emails?')) {
-            deleteAllMutation.mutate()
-          }
+          deleteAllMutation.mutate(undefined, {
+            // Clear the reading pane so a deleted email can't linger on screen.
+            onSuccess: () => setSelectedEmail(null),
+          })
         },
         keywords: ['remove', 'clear', 'empty'],
       },

--- a/packages/ui/src/hooks/useCommands.tsx
+++ b/packages/ui/src/hooks/useCommands.tsx
@@ -254,7 +254,7 @@ export function useCommands(): Command[] {
         category: 'email',
         icon: <TrashIcon />,
         action: () => {
-          if (selectedEmailId && window.confirm('Delete this email?')) {
+          if (selectedEmailId) {
             api.emails.delete(selectedEmailId).then(() => {
               // The deleted email's route is gone; replace so Back doesn't
               // return to a now-404 selection.

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -104,21 +104,19 @@ export function useKeyboardShortcuts() {
 
         case 'Delete':
         case 'Backspace': {
-          // Delete selected email
+          // Delete selected email (no confirmation — matches v2 behavior)
           if (selectedEmailId) {
             e.preventDefault()
-            if (window.confirm('Delete this email?')) {
-              // Find next email to select before deleting (from visible list)
-              const nextIndex = currentIndex < visibleEmails.length - 1 ? currentIndex + 1 : currentIndex - 1
-              const nextEmail = visibleEmails[nextIndex]
+            // Find next email to select before deleting (from visible list)
+            const nextIndex = currentIndex < visibleEmails.length - 1 ? currentIndex + 1 : currentIndex - 1
+            const nextEmail = visibleEmails[nextIndex]
 
-              api.emails.delete(selectedEmailId).then(() => {
-                // The deleted email's route is gone; replace so Back doesn't
-                // return to a now-404 selection.
-                setSelectedEmail(nextEmail?.id ?? null, { replace: true })
-                refresh()
-              })
-            }
+            api.emails.delete(selectedEmailId).then(() => {
+              // The deleted email's route is gone; replace so Back doesn't
+              // return to a now-404 selection.
+              setSelectedEmail(nextEmail?.id ?? null, { replace: true })
+              refresh()
+            })
           }
           break
         }

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -104,7 +104,7 @@ export function useKeyboardShortcuts() {
 
         case 'Delete':
         case 'Backspace': {
-          // Delete selected email (no confirmation — matches v2 behavior)
+          // Delete selected email (no confirmation)
           if (selectedEmailId) {
             e.preventDefault()
             // Find next email to select before deleting (from visible list)


### PR DESCRIPTION
Closes #576.

## Background

@dharrigan reported that v3 regressed the email-deletion experience compared to v2, adding confirmation friction that wasn't there before. Checking the v2.2.1 source confirmed the original behavior:

- **Delete all** used an inline two-click safeguard (the trash icon turned red; a second click within a short window deleted everything) — never a modal.
- **Single-email delete** happened immediately on click, with **no confirmation at all**.
- Only **relay** was guarded by a confirm dialog (it's the genuinely irreversible, outward-facing action).

v3 had replaced the delete-all safeguard with a blocking `window.confirm`, added a confirm to single-email delete, and left an open email lingering in the reading pane after delete-all.

## What this does

Restores v2's behavior across the board:

### Delete all
- **First click** arms the trash button — it turns solid red and **slides open to reveal "Confirm"** via a CSS width + opacity transition. Tooltip updates to _"Click again to delete all emails."_
- **Second click within 2s** deletes everything. If the window lapses, the button quietly resets.
- Accessible name toggles between `Delete all emails` and `Confirm delete all emails` so screen readers track the armed state.

### Single-email delete
- Removed the `window.confirm` prompt — deletes on click, matching v2. Applied to all three entry points: the email-header button, the command palette, and the Del/Backspace shortcut (which stays guarded against firing while typing in an input).

### Reading-pane bug
- Deleting all emails now clears the reading pane (`setSelectedEmail(null)`) instead of leaving a now-deleted email on screen.

Relay confirmations are left intact, matching v2. No new config/env toggle — this was simply v2's default.

## Verification

Ran the app (`pnpm dev`) and drove the delete-all flow end-to-end in a browser:

- First click → button turns red and slides out to "Confirm" ✅
- No second click → auto-resets after 2s, nothing deleted ✅
- Second click within window → all emails deleted, reading pane resets to "Select an email to view", route returns to `#/`, backend store confirmed empty (`storeTotal: 0`) ✅

`pnpm --filter @maildev/ui typecheck`, `lint`, and `test` (40 tests) all pass.