### PR TITLE
fix: honor `smtp: 0` and expose the bound port on the programmatic API

### DIFF
--- a/.changeset/ephemeral-port.md
+++ b/.changeset/ephemeral-port.md
@@ -1,0 +1,16 @@
+---
+'@maildev/smtp': patch
+'@maildev/api': patch
+'maildev': patch
+---
+
+Honour `port: 0` and expose the bound port on the programmatic API (#567).
+
+Previously `new MailDev({ smtp: 0 })` was silently ignored — `options.port || DEFAULT_PORT` treated an explicit `0` as absent and fell back to 1025. It now uses `??`, so `0` requests an OS-assigned ephemeral port, and the port that was actually bound is read back from the listening socket.
+
+Both servers now expose their bound address:
+
+- `SMTPServer#getAddress()` → `{ host, port }` and `SMTPServer#getPort()`
+- `APIServer#getAddress()` → `{ host, port } | null` and `APIServer#getPort()` (null until listening)
+
+Together these let you run one MailDev per worker under a parallel test runner without hand-assigning ports.

--- a/.changeset/ephemeral-port.md
+++ b/.changeset/ephemeral-port.md
@@ -4,7 +4,7 @@
 'maildev': patch
 ---
 
-Honour `port: 0` and expose the bound port on the programmatic API (#567).
+Honor `port: 0` and expose the bound port on the programmatic API (#567).
 
 Previously `new MailDev({ smtp: 0 })` was silently ignored — `options.port || DEFAULT_PORT` treated an explicit `0` as absent and fell back to 1025. It now uses `??`, so `0` requests an OS-assigned ephemeral port, and the port that was actually bound is read back from the listening socket.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -181,7 +181,7 @@ positive limit for long-running or high-volume use.
 
 ### Listing a large inbox
 
-`smtp.getAllEmails()` materialises every email, bodies included. For listings,
+`smtp.getAllEmails()` materializes every email, bodies included. For listings,
 use `storage.list()` instead — it returns a page of emails plus the counts
 needed to paginate, so the work stays proportional to the page size rather than
 the size of the store.

--- a/docs/api.md
+++ b/docs/api.md
@@ -107,6 +107,38 @@ if (maildev.isRunning()) {
 const servers = maildev.getServers()
 ```
 
+## Ephemeral ports
+
+Pass `smtp: 0` (and/or `web: 0`) to have the OS assign a free port, then read
+back the port that was actually bound. This is the reliable way to run one
+MailDev per worker under a parallel test runner without hand-assigning ports.
+
+```typescript
+const maildev = new MailDev({ smtp: 0, disableWeb: true })
+const { smtp } = await maildev.start()
+
+const { host, port } = smtp.getAddress()
+console.log(`SMTP listening on ${host}:${port}`)
+
+// Point your app's mail transport at `port` — e.g. nodemailer:
+// nodemailer.createTransport({ host, port, secure: false })
+```
+
+Both the SMTP and API servers expose the bound address:
+
+- `smtp.getAddress()` → `{ host, port }` (and `smtp.getPort()`)
+- `servers.api?.getAddress()` → `{ host, port } | null` (and `api.getPort()`)
+
+The API server's accessors return `null` until it is listening.
+
+```typescript
+const maildev = new MailDev({ smtp: 0, web: 0 })
+const { smtp, api } = await maildev.start()
+
+const smtpPort = smtp.getPort()          // OS-assigned SMTP port
+const webPort = api?.getPort()           // OS-assigned web/API port
+```
+
 ## Working with Emails
 
 Once MailDev is running, you can access emails through the SMTP server instance.

--- a/packages/api/src/__tests__/server.test.ts
+++ b/packages/api/src/__tests__/server.test.ts
@@ -25,6 +25,24 @@ describe('APIServer', () => {
     })
   })
 
+  describe('getAddress', () => {
+    it('returns null before the server is listening', () => {
+      server = createAPIServer({ storage, port: 0 })
+      expect(server.getAddress()).toBeNull()
+      expect(server.getPort()).toBeNull()
+    })
+
+    it('exposes the OS-assigned ephemeral port after listening with port 0', async () => {
+      server = createAPIServer({ storage, port: 0 })
+      await server.start()
+
+      const address = server.getAddress()
+      expect(address).not.toBeNull()
+      expect(address!.port).toBeGreaterThan(0)
+      expect(server.getPort()).toBe(address!.port)
+    })
+  })
+
   describe('health check', () => {
     it('should return true on GET /api/healthz', async () => {
       server = createAPIServer({ storage, port: 0 })

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -39,7 +39,7 @@ const DEFAULT_HOST = '0.0.0.0'
  * Upper bound on how many summaries a single request can ask for
  *
  * A client that asks for everything still gets a bounded response, so no single
- * request can pin the event loop serialising the whole inbox.
+ * request can pin the event loop serializing the whole inbox.
  */
 const MAX_PAGE_SIZE = 200
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -73,6 +73,7 @@ export class APIServer extends EventEmitter {
   private options: APIServerOptions
   private mcpTransports: Map<string, StreamableHTTPServerTransport> = new Map()
   private pluginsRegistered = false
+  private boundAddress: { host: string; port: number } | null = null
 
   constructor(options: APIServerOptions) {
     super()
@@ -146,11 +147,37 @@ export class APIServer extends EventEmitter {
 
     await this.app.listen({ port, host })
 
+    // Record the port the OS actually bound. When `port: 0` was requested this
+    // is the assigned ephemeral port; getAddress()/getPort() then let the
+    // caller discover it.
+    const address = this.app.server.address()
+    const boundPort = address && typeof address === 'object' ? address.port : port
+    this.boundAddress = { host, port: boundPort }
+
     const printHost = host === '0.0.0.0' ? 'localhost' : host
     const protocol = this.options.https ? 'https' : 'http'
-    console.info(`MailDev API running at ${protocol}://${printHost}:${port}${this.options.basePath ?? ''}`)
+    console.info(`MailDev API running at ${protocol}://${printHost}:${boundPort}${this.options.basePath ?? ''}`)
 
-    this.emit('listening', { port, host })
+    this.emit('listening', { port: boundPort, host })
+  }
+
+  /**
+   * Get the address the API server is bound to, or null before it listens
+   *
+   * After listen(), the port reflects the actual bound port — so a server
+   * started with `port: 0` reports the OS-assigned ephemeral port here.
+   */
+  getAddress(): { host: string; port: number } | null {
+    return this.boundAddress
+  }
+
+  /**
+   * Get the port the API server is bound to, or null before it listens
+   *
+   * After listen() with `port: 0`, this is the OS-assigned ephemeral port.
+   */
+  getPort(): number | null {
+    return this.boundAddress?.port ?? null
   }
 
   /**

--- a/packages/cli/src/server/orchestrator.ts
+++ b/packages/cli/src/server/orchestrator.ts
@@ -110,7 +110,10 @@ export class Orchestrator {
 
     // 6. Start SMTP server
     await this.smtp.start()
-    this.logger.debug(`SMTP server started on ${this.config.ip}:${this.config.smtp}`)
+    // Log the bound address, not the requested one, so `smtp: 0` reports the
+    // OS-assigned ephemeral port rather than 0.
+    const smtpAddress = this.smtp.getAddress()
+    this.logger.debug(`SMTP server started on ${smtpAddress.host}:${smtpAddress.port}`)
 
     // 6b. Keep the on-disk mail directory bounded when a limit is set: discard
     // .eml files left over from previous runs beyond the limit. A directory
@@ -178,7 +181,8 @@ export class Orchestrator {
       await this.api.registerPlugins()
       await registerUI(this.api.server, { basePath })
       await this.api.listen()
-      this.logger.debug(`API server started on ${this.config.webIp}:${this.config.web}`)
+      const apiAddress = this.api.getAddress()
+      this.logger.debug(`API server started on ${apiAddress?.host ?? this.config.webIp}:${apiAddress?.port ?? this.config.web}`)
     }
 
     this.running = true

--- a/packages/smtp/src/__tests__/ephemeral-port.test.ts
+++ b/packages/smtp/src/__tests__/ephemeral-port.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import nodemailer from 'nodemailer'
+import { MemoryStorage } from '@maildev/core'
+import { SMTPServer } from '../server.js'
+
+describe('ephemeral port (port: 0)', () => {
+  let mailDir: string
+  let storage: MemoryStorage
+  let server: SMTPServer
+
+  beforeEach(async () => {
+    mailDir = await mkdtemp(join(tmpdir(), 'maildev-port-'))
+    storage = new MemoryStorage()
+    await storage.initialize()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+    await rm(mailDir, { recursive: true, force: true })
+  })
+
+  it('binds an OS-assigned port and exposes it via getAddress()/getPort()', async () => {
+    server = new SMTPServer({ storage, mailDir, port: 0, host: '127.0.0.1' })
+    await server.start()
+
+    const { host, port } = server.getAddress()
+    expect(host).toBe('127.0.0.1')
+    expect(port).toBeGreaterThan(0)
+    expect(server.getPort()).toBe(port)
+
+    // The reported port is real: a message sent to it is received and stored.
+    const transport = nodemailer.createTransport({ host: '127.0.0.1', port, secure: false })
+    await transport.sendMail({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 'ephemeral',
+      text: 'hello',
+    })
+    expect(await storage.getAll()).toHaveLength(1)
+  })
+
+  it('gives each port: 0 server its own port instead of coercing to the default', async () => {
+    // If `0` were treated as absent and replaced by DEFAULT_PORT, both servers
+    // would try to bind the same fixed port and the second would EADDRINUSE.
+    // Both succeeding on distinct ports proves `0` flows through as `0`.
+    server = new SMTPServer({ storage, mailDir, port: 0, host: '127.0.0.1' })
+    await server.start()
+
+    const other = new SMTPServer({ storage, mailDir, port: 0, host: '127.0.0.1' })
+    await other.start()
+    try {
+      expect(server.getPort()).toBeGreaterThan(0)
+      expect(other.getPort()).toBeGreaterThan(0)
+      expect(other.getPort()).not.toBe(server.getPort())
+    } finally {
+      await other.stop()
+    }
+  })
+})

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -80,7 +80,7 @@ export class SMTPServer extends EventEmitter {
     this.storage = options.storage
     this.mailDir = options.mailDir
     // Use ?? so an explicit `port: 0` (bind an OS-assigned ephemeral port) is
-    // honoured rather than falling back to the default — `0 || DEFAULT` would
+    // honored rather than falling back to the default — `0 || DEFAULT` would
     // treat a meaningful 0 as absent. The real port is read back from the
     // listening socket in start() and exposed via getAddress()/getPort().
     this.port = options.port ?? DEFAULT_PORT

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -79,7 +79,11 @@ export class SMTPServer extends EventEmitter {
 
     this.storage = options.storage
     this.mailDir = options.mailDir
-    this.port = options.port || DEFAULT_PORT
+    // Use ?? so an explicit `port: 0` (bind an OS-assigned ephemeral port) is
+    // honoured rather than falling back to the default — `0 || DEFAULT` would
+    // treat a meaningful 0 as absent. The real port is read back from the
+    // listening socket in start() and exposed via getAddress()/getPort().
+    this.port = options.port ?? DEFAULT_PORT
     this.host = options.host || DEFAULT_HOST
     this.options = options
     this.logger = createLogger(options.logger)
@@ -115,11 +119,38 @@ export class SMTPServer extends EventEmitter {
           return
         }
 
+        // Record the port the OS actually bound. When `port: 0` was requested
+        // this is the assigned ephemeral port; getAddress()/getPort() then let
+        // the caller discover it (e.g. one MailDev per parallel test worker).
+        const address = this.smtp!.server.address()
+        if (address && typeof address === 'object') {
+          this.port = address.port
+        }
+
         const printHost = this.host === '::' ? 'localhost' : this.host
         this.logger.info(`SMTP Server running at ${printHost}:${this.port}`)
         resolve()
       })
     })
+  }
+
+  /**
+   * Get the address the SMTP server is bound to
+   *
+   * After start(), the port reflects the actual bound port — so a server
+   * started with `port: 0` reports the OS-assigned ephemeral port here.
+   */
+  getAddress(): { host: string; port: number } {
+    return { host: this.host, port: this.port }
+  }
+
+  /**
+   * Get the port the SMTP server is bound to
+   *
+   * After start() with `port: 0`, this is the OS-assigned ephemeral port.
+   */
+  getPort(): number {
+    return this.port
   }
 
   /**


### PR DESCRIPTION
Closes #567

## Problem

When embedding MailDev programmatically, `new MailDev({ smtp: 0 })` was silently ignored and 1025 was used instead, and there was no way to read back the port a server actually bound to. Together these blocked giving each parallel test worker its own MailDev instance without hand-assigning ports.

The cause is `options.port || DEFAULT_PORT` in the SMTP server: `0 || 1025 === 1025`, so a meaningful `0` is treated as absent. The port was also `private` with no accessor.

## Changes

- **`@maildev/smtp`** — switch `||` → `??` so an explicit `port: 0` is honored; read the actually-bound port back from the listening socket in `start()`; add `getAddress()` → `{ host, port }` and `getPort()`.
- **`@maildev/api`** — record the real bound port after `listen()` (also fixes the `listening` event, which previously emitted the requested `0`); add `getAddress()` → `{ host, port } | null` and `getPort()` (null until listening).
- **`maildev` (orchestrator)** — debug logs now print the real bound addresses instead of the requested `0`.
- **Docs** — new "Ephemeral ports" section in `docs/api.md` covering the parallel-test-runner use case.
- **Tests** — new `ephemeral-port.test.ts` (binds an ephemeral port and it's usable; two `port: 0` servers get distinct ports, proving `0` isn't coerced to the default) plus an API `getAddress()` test.

## Usage

```js
const maildev = new MailDev({ smtp: 0, disableWeb: true })
const { smtp } = await maildev.start()

const { host, port } = smtp.getAddress()
// point your app's mail transport at `port`
```

## Verification

- Full suite passes (342 tests), plus `typecheck` and `lint`.
- The issue's exact reproduction now binds an ephemeral port while 1025 is occupied and reads it back via `smtp.getAddress()`.

## Notes

- Scoped to `0`-handling + port exposure. #568 (start() rejecting cleanly instead of crashing on `EADDRINUSE`) is left as a separate change, as the issue suggests.
- The repo has two `@types/node` versions installed (22.x and 25.x); 25.x's `net.Server` type doesn't surface EventEmitter methods, which is why the new test avoids `.on`/`.once` on raw sockets. Worth deduping separately.

