### PR TITLE
fix: reject start() when the SMTP port is already bound (#568)

### DIFF
--- a/packages/smtp/src/__tests__/start-errors.test.ts
+++ b/packages/smtp/src/__tests__/start-errors.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import net, { type AddressInfo } from 'node:net'
+import { MemoryStorage } from '@maildev/core'
+import { SMTPServer } from '../server.js'
+
+/** Drive smtp-server's 'error' event, the same path handleServerError listens on. */
+function emitSmtpError(server: SMTPServer, err: NodeJS.ErrnoException): void {
+  const smtpLib = (
+    server as unknown as {
+      smtp: { emit: (event: 'error', err: NodeJS.ErrnoException) => void }
+    }
+  ).smtp
+  smtpLib.emit('error', err)
+}
+
+describe('SMTPServer start() errors', () => {
+  let mailDir: string
+  let storage: MemoryStorage
+  let server: SMTPServer | undefined
+  let occupant: net.Server | undefined
+
+  beforeEach(async () => {
+    mailDir = await mkdtemp(join(tmpdir(), 'maildev-start-err-'))
+    storage = new MemoryStorage()
+    await storage.initialize()
+  })
+
+  afterEach(async () => {
+    await server?.stop()
+    if (occupant) {
+      await new Promise<void>((resolve, reject) => {
+        occupant!.close((err) => (err ? reject(err) : resolve()))
+      })
+      occupant = undefined
+    }
+    await rm(mailDir, { recursive: true, force: true })
+  })
+
+  it('rejects start() with EADDRINUSE when the SMTP port is already bound', async () => {
+    occupant = net.createServer()
+    await new Promise<void>((resolve) => {
+      occupant!.listen(0, '127.0.0.1', () => resolve())
+    })
+    const port = (occupant.address() as AddressInfo).port
+
+    const uncaught: Error[] = []
+    const onUncaught = (err: Error) => {
+      uncaught.push(err)
+    }
+    process.on('uncaughtException', onUncaught)
+
+    try {
+      server = new SMTPServer({
+        storage,
+        mailDir,
+        port,
+        host: '127.0.0.1',
+        logger: false,
+      })
+      await expect(server.start()).rejects.toMatchObject({ code: 'EADDRINUSE' })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect(uncaught).toEqual([])
+    } finally {
+      process.removeListener('uncaughtException', onUncaught)
+    }
+  })
+
+  it('does not throw from a post-listen server error when no error listener is attached', async () => {
+    server = new SMTPServer({
+      storage,
+      mailDir,
+      port: 0,
+      host: '127.0.0.1',
+      logger: false,
+    })
+    await server.start()
+
+    const err = Object.assign(new Error('timeout'), {
+      code: 'ETIMEDOUT',
+    }) as NodeJS.ErrnoException
+    expect(() => emitSmtpError(server!, err)).not.toThrow()
+  })
+
+  it('forwards post-listen errors to an error listener instead of throwing', async () => {
+    server = new SMTPServer({
+      storage,
+      mailDir,
+      port: 0,
+      host: '127.0.0.1',
+      logger: false,
+    })
+    await server.start()
+
+    const seen: NodeJS.ErrnoException[] = []
+    server.on('error', (e: NodeJS.ErrnoException) => {
+      seen.push(e)
+    })
+
+    const err = Object.assign(new Error('timeout'), {
+      code: 'ETIMEDOUT',
+    }) as NodeJS.ErrnoException
+    expect(() => emitSmtpError(server!, err)).not.toThrow()
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({ code: 'ETIMEDOUT' })
+  })
+})

--- a/packages/smtp/src/server.ts
+++ b/packages/smtp/src/server.ts
@@ -106,18 +106,26 @@ export class SMTPServer extends EventEmitter {
 
     this.smtp = new SMTPServerLib(config)
 
-    // Handle server errors
-    this.smtp.on('error', (err: NodeJS.ErrnoException) => {
-      this.handleServerError(err)
-    })
-
-    // Start listening
+    // Node's server.listen() callback is the 'listening' listener, not an
+    // error-first callback. Bind failures (EADDRINUSE, EACCES, …) arrive on
+    // 'error' instead, so reject start() from that event until we are listening.
     return new Promise((resolve, reject) => {
+      const onStartupError = (err: Error) => {
+        reject(err)
+      }
+      this.smtp!.once('error', onStartupError)
+
       this.smtp!.listen(this.port, this.host, (err?: Error) => {
         if (err) {
+          this.smtp!.off('error', onStartupError)
           reject(err)
           return
         }
+
+        this.smtp!.off('error', onStartupError)
+        this.smtp!.on('error', (e: NodeJS.ErrnoException) => {
+          this.handleServerError(e)
+        })
 
         // Record the port the OS actually bound. When `port: 0` was requested
         // this is the assigned ephemeral port; getAddress()/getPort() then let
@@ -857,8 +865,12 @@ export class SMTPServer extends EventEmitter {
       )
       this.logger.debug?.(err)
     } else {
-      this.emit('error', err)
-      throw err
+      // Do not throw: this runs from an event callback, so a throw is uncaught
+      // and kills the process. A bare emit('error') with no listener does too.
+      this.logger.error(err.message)
+      if (this.listenerCount('error') > 0) {
+        this.emit('error', err)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- If the SMTP bind fails (`EADDRINUSE`, `EACCES`, …), `SMTPServer.start()` now rejects with that error instead of hanging forever.
- `handleServerError` no longer re-throws. Post-listen errors (`ETIMEDOUT`, …) are logged, and `error` is emitted only when a caller has subscribed — so a `try`/`catch` around `maildev.start()` actually works.
- `port: 0` (ephemeral bind) is unchanged.

Closes #568.

## Decision

- **Chose:** attach `once('error')` for the duration of `listen()`, then swap to `handleServerError`; never throw from the handler; `emit('error')` only if there is a listener.
- **Alternative:** a `listening` flag and a stored `reject` inside a single `handleServerError`.
- **Why:** that is the shape described on #568. Same behaviour, slightly clearer lifecycle.
- Happy to switch to the single-handler version if you prefer it.

No changeset in this PR. Happy to add a patch bump for `@maildev/smtp` / `maildev` if you want this in the rc changelog.

## Test plan

- [x] Occupy a port, `new SMTPServer({ port, host: '127.0.0.1' })`, `await start()` rejects with `{ code: 'EADDRINUSE' }`; no `uncaughtException`.
- [x] After a successful listen, a fake `ETIMEDOUT` on the smtp-server instance does not throw; with an `error` listener it is forwarded.
- [x] Existing `port: 0` tests still pass.
- [x] `pnpm --filter @maildev/smtp test` — 10 files, 64 tests passed.
- [ ] Optional: `new MailDev({ smtp: occupied, disableWeb: true, silent: true })` — `await maildev.start()` rejects; process stays up.
