### PR TITLE
fix: honor MAILDEV_AUTO_RELAY and MAILDEV_AUTO_RELAY_RULES env vars (#327)

### DIFF
--- a/.changeset/fix-auto-relay-env.md
+++ b/.changeset/fix-auto-relay-env.md
@@ -1,0 +1,9 @@
+---
+'maildev': patch
+---
+
+Honor `MAILDEV_AUTO_RELAY` and `MAILDEV_AUTO_RELAY_RULES` so Docker and other
+env-based setups can enable auto-relay the same way `--auto-relay` and
+`--auto-relay-rules` do. `true`, `1`, and a present-but-empty value relay to
+each mail's own recipients; `false` and `0` disable; any other value is the
+override recipient.

--- a/packages/cli/src/__tests__/config/env.test.ts
+++ b/packages/cli/src/__tests__/config/env.test.ts
@@ -120,6 +120,50 @@ describe('loadEnvConfig', () => {
     expect(config.ip).toBe('0.0.0.0')
     expect(config.mailDirectory).toBe('/tmp/mail')
   })
+
+  it('should parse MAILDEV_AUTO_RELAY=true as boolean true', () => {
+    process.env.MAILDEV_AUTO_RELAY = 'true'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe(true)
+  })
+
+  it('should parse MAILDEV_AUTO_RELAY=1 as boolean true', () => {
+    process.env.MAILDEV_AUTO_RELAY = '1'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe(true)
+  })
+
+  it('should parse present-but-empty MAILDEV_AUTO_RELAY as boolean true', () => {
+    process.env.MAILDEV_AUTO_RELAY = ''
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe(true)
+  })
+
+  it('should parse MAILDEV_AUTO_RELAY as a recipient email', () => {
+    process.env.MAILDEV_AUTO_RELAY = 'qa@example.com'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe('qa@example.com')
+  })
+
+  it('should load MAILDEV_AUTO_RELAY_RULES as a path string', () => {
+    process.env.MAILDEV_AUTO_RELAY_RULES = '/config/rules.json'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelayRules).toBe('/config/rules.json')
+  })
+
+  it('should leave autoRelay and autoRelayRules unset when env vars are absent', () => {
+    delete process.env.MAILDEV_AUTO_RELAY
+    delete process.env.MAILDEV_AUTO_RELAY_RULES
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBeUndefined()
+    expect(config.autoRelayRules).toBeUndefined()
+  })
 })
 
 describe('getEnvVarName', () => {

--- a/packages/cli/src/__tests__/config/env.test.ts
+++ b/packages/cli/src/__tests__/config/env.test.ts
@@ -142,6 +142,20 @@ describe('loadEnvConfig', () => {
     expect(config.autoRelay).toBe(true)
   })
 
+  it('should parse MAILDEV_AUTO_RELAY=false as boolean false', () => {
+    process.env.MAILDEV_AUTO_RELAY = 'false'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe(false)
+  })
+
+  it('should parse MAILDEV_AUTO_RELAY=0 as boolean false', () => {
+    process.env.MAILDEV_AUTO_RELAY = '0'
+
+    const config = loadEnvConfig()
+    expect(config.autoRelay).toBe(false)
+  })
+
   it('should parse MAILDEV_AUTO_RELAY as a recipient email', () => {
     process.env.MAILDEV_AUTO_RELAY = 'qa@example.com'
 

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -76,12 +76,16 @@ function parseBoolean(value: string): boolean {
 
 /**
  * MAILDEV_AUTO_RELAY is boolean | string: true/1/empty enable relay to
- * each mail's own recipients; any other value is the override recipient.
+ * each mail's own recipients; false/0 disable; any other value is the
+ * override recipient.
  * Do not put this in BOOLEAN_VARS — that would parse an email as false.
  */
 function parseAutoRelay(value: string): boolean | string {
   if (value === '' || value.toLowerCase() === 'true' || value === '1') {
     return true
+  }
+  if (value.toLowerCase() === 'false' || value === '0') {
+    return false
   }
   return value
 }

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -32,6 +32,8 @@ const ENV_MAPPING: Record<string, keyof PartialMailDevConfig> = {
   MAILDEV_OUTGOING_PORT: 'outgoingPort',
   MAILDEV_OUTGOING_USER: 'outgoingUser',
   MAILDEV_OUTGOING_PASS: 'outgoingPass',
+  MAILDEV_AUTO_RELAY: 'autoRelay',
+  MAILDEV_AUTO_RELAY_RULES: 'autoRelayRules',
 
   // Storage
   MAILDEV_MAIL_DIRECTORY: 'mailDirectory',
@@ -73,6 +75,18 @@ function parseBoolean(value: string): boolean {
 }
 
 /**
+ * MAILDEV_AUTO_RELAY is boolean | string: true/1/empty enable relay to
+ * each mail's own recipients; any other value is the override recipient.
+ * Do not put this in BOOLEAN_VARS — that would parse an email as false.
+ */
+function parseAutoRelay(value: string): boolean | string {
+  if (value === '' || value.toLowerCase() === 'true' || value === '1') {
+    return true
+  }
+  return value
+}
+
+/**
  * Load configuration from environment variables
  *
  * @returns Partial configuration from environment
@@ -84,7 +98,9 @@ export function loadEnvConfig(): PartialMailDevConfig {
     const value = process.env[envVar]
     if (value === undefined) continue
 
-    if (NUMBER_VARS.has(envVar)) {
+    if (envVar === 'MAILDEV_AUTO_RELAY') {
+      config.autoRelay = parseAutoRelay(value)
+    } else if (NUMBER_VARS.has(envVar)) {
       const num = parseInt(value, 10)
       if (!isNaN(num)) {
         ;(config as Record<string, unknown>)[configKey] = num


### PR DESCRIPTION

## Summary

`MAILDEV_AUTO_RELAY` and `MAILDEV_AUTO_RELAY_RULES` were documented (README) and used in Docker/Kubernetes, but `loadEnvConfig` never mapped them, so setting them (empty, `true`, or an email) had no effect. Auto-relay only worked via `--auto-relay [email]` or a config file.

`MAILDEV_AUTO_RELAY=true` was also the historical trap: when the value *was* read (v2 / custom images), it was treated as a recipient named `true`. Putting the var through the generic boolean parser would make an email like `qa@example.com` parse as `false`.

`loadEnvConfig` now maps:

- `MAILDEV_AUTO_RELAY=true`, `1`, or present-but-empty (`MAILDEV_AUTO_RELAY=`) → `autoRelay: true` (relay to each mail’s own recipients, honoring rules)
- any other `MAILDEV_AUTO_RELAY` value → that string as the override recipient
- `MAILDEV_AUTO_RELAY_RULES` → `autoRelayRules` (path)

Unset still means off. The config model already had `autoRelay?: boolean | string`; this is only the env wiring.

**What I chose:** special-case `boolean | string` in `env.ts`, matching `--auto-relay [email]`.
**Alternative:** treat the env var as boolean-only (`BOOLEAN_VARS`) and keep the recipient override on the CLI flag / config file. That would document `MAILDEV_AUTO_RELAY=true` and reject emails, but it would not match the README column or the maintainer note on this issue. Happy to switch if you would rather treat `false`/`0` as off (today those strings become the recipient, per “any other value is the override email”).

Fixes #327

## Test plan

- [x] `MAILDEV_AUTO_RELAY=true` / `1` / `''` → `autoRelay === true` (not `"true"`)
- [x] `MAILDEV_AUTO_RELAY=qa@example.com` → that string
- [x] `MAILDEV_AUTO_RELAY_RULES=/config/rules.json` → that path
- [x] vars absent → `autoRelay` / `autoRelayRules` unset
- [x] `pnpm --filter maildev test` (111 passed)
- [ ] Docker: `MAILDEV_AUTO_RELAY=` plus `MAILDEV_AUTO_RELAY_RULES` enables relay to rule matches without a catch-all address
- [ ] `MAILDEV_AUTO_RELAY=you@example.com` overrides recipients
